### PR TITLE
Single binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-node_modules
-build
-bin
+/node_modules
+/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ before_install:
   - nvm use 8
   - npm install -g yarn
   - yarn install -prod false
+  - touch .env
 
 script:
-  - yarn lint
-  - yarn test
-  - touch .env
-  - make dependencies
+  - make lint-frontend
+  - make test-frontend
+  - make dependencies-backend
+  # uncommend next line when BE code will start passing go lint and go vet
+  # - make lint-backend
   - make test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,39 @@ plumbing: packp, Skip argument validations for unknown capabilities. Fixes #623
 > Please note: you will need a .env file configured with working GitHub OAuth credentials to run the application in development mode.
 > Please follow the [README Installation section](./README.md#installation) for instructions on how to do it.
 
-To build and run the tool, execute:
+### Global dependencies
+
+You should already have [Go installed](https://golang.org/doc/install#install), and properly [configured the $GOPATH](https://github.com/golang/go/wiki/SettingGOPATH)
+
+```
+go version; # prints your go version
+echo $GOPATH; # prints your $GOPATH path
+```
+
+The project must be under $GOPATH, as required by the Go tooling.
+You should be able to navigate into the source code by running:
+
+```
+cd $GOPATH/src/github.com/src-d/code-annotation
+```
+
+You need also [Yarn v1.x.x installed](https://yarnpkg.com/en/docs/install)
+
+```
+yarn --version; # prints your Yarn version
+```
+
+## Installation
+
+You need to satisfy all [project requirements](#requirements), and then run:
 
 ```bash
 $ go get -d -u github.com/src-d/code-annotation/...
 $ cd $GOPATH/github.com/src-d/code-annotation
 $ make serve
 ```
+
+This will start a server locally, which you can access on [http://localhost:8080](http://localhost:8080)
 
 ### Frontend:
 
@@ -70,7 +96,7 @@ $ UI_DOMAIN=http://127.0.0.1:3000 make gorun
 And then run frontend in dev mode. Execute:
 
 ```bash
-$ yarn start
+$ make dev-frontend
 ```
 
 ### Backend:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,3 @@
-FROM golang:1.8-alpine3.6
-
-# base deps
-RUN apk --update upgrade && \
-    apk add --no-cache make git curl ca-certificates bash \
-    build-base libxml2-dev protobuf nodejs=6.10.3-r1 nodejs-npm && \
-    npm install -g yarn
-
-ADD . /go/src/code-annotation
-WORKDIR /go/src/code-annotation
-
-RUN make build && \
-    make packages
-
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-WORKDIR /root/
-COPY --from=0 /go/src/code-annotation/build ./build
-COPY --from=0 /go/src/code-annotation/bin/code-annotation .
-CMD ["./code-annotation"]
+FROM alpine:3.6
+ADD ./build/bin /bin
+ENTRYPOINT ["/bin/code-annotation"]

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,74 @@
 # Package configuration
 PROJECT = code-annotation
 COMMANDS = cli/server
-DEPENDENCIES = github.com/golang/dep/cmd/dep
+DEPENDENCIES = github.com/golang/dep/cmd/dep github.com/jteeuwen/go-bindata
 
 HOST ?= 127.0.0.1
 PORT ?= 8080
 SERVER_URL ?= //$(HOST):$(PORT)
+
+# Tools
+YARN = yarn
+GODEP = dep
+GOLINT = golint
+GOVET = go vet
+BINDATA = go-bindata
 
 # Including ci Makefile
 CI_REPOSITORY ?= https://github.com/src-d/ci.git
 CI_PATH ?= $(shell pwd)/.ci
 MAKEFILE := $(CI_PATH)/Makefile.main
 $(MAKEFILE):
-	git clone --quiet --depth 1 $(CI_REPOSITORY) $(CI_PATH);
+	@git clone --quiet --depth 1 -b v1 $(CI_REPOSITORY) $(CI_PATH);
+
 -include $(MAKEFILE)
 
 # set enviroment variables from .env file
 include .env
 export $(shell sed 's/=.*//' .env)
 
-# Tools
-YARN = yarn
-REMOVE = rm -rf
+# Frontend
 
-godep:
-	dep ensure
-
-dependencies-frontend: godep
+dependencies-frontend:
 	$(YARN)	install
 
 test-frontend: dependencies-frontend
 	$(YARN) test
 
-lint: dependencies-frontend
+lint-frontend: dependencies-frontend
 	$(YARN) lint
 
-build: dependencies-frontend
+build-frontend: dependencies-frontend
 	REACT_APP_SERVER_URL=$(SERVER_URL) $(YARN) build
 
-## Compiles the dashboard assets, and serve the dashboard through its API
-serve: build
-	go run cli/server/server.go
+dev-frontend: dependencies-frontend
+	$(YARN) start
 
+# Backend
+
+dependencies-backend: $(DEPENDENCIES)
+	$(GODEP) ensure
+
+build-backend: dependencies-backend
+
+lint-backend: dependencies-backend
+	$(GOLINT) ./server/...
+	$(GOVET) ./server/...
+	
+bindata:
+	$(BINDATA) -o ./server/assets/asset.go -pkg assets build/static/... build/*.json build/*.png build/index.html
+
+prepare-build: | build-frontend build-backend bindata
+
+# Run only server
 gorun:
 	go run cli/server/server.go
+
+## Compiles the assets, and serve the tool through its API
+serve: build-frontend build-backend gorun
+
+.PHONY: dependencies-frontend build-frontend dev-frontend \
+		test-frontend lint-frontend \
+		dependencies-backend build-backend release-build \
+		lint-backend bindata \
+		gorun serve

--- a/README.md
+++ b/README.md
@@ -18,31 +18,9 @@ Source code annotation tool offers an UI to annotate source code and review thes
 
 ![Screenshot](.github/screenshot.png?raw=true)
 
-## Requirements
+## Installation
 
-### Global dependencies
-
-You should already have [Go installed](https://golang.org/doc/install#install), and properly [configured the $GOPATH](https://github.com/golang/go/wiki/SettingGOPATH)
-
-```
-go version; # prints your go version
-echo $GOPATH; # prints your $GOPATH path
-```
-
-The project must be under $GOPATH, as required by the Go tooling.
-You should be able to navigate into the source code by running:
-
-```
-cd $GOPATH/src/github.com/src-d/code-annotation
-```
-
-You need also [Yarn v1.x.x installed](https://yarnpkg.com/en/docs/install)
-
-```
-yarn --version; # prints your Yarn version
-```
-
-### Github OAuth tokens
+## Github OAuth tokens
 
 1. You need an OAuth application on GitHub. See [how to create OAuth applications on GitHub](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/).
 
@@ -52,17 +30,13 @@ In order to be able to use this application while running the tool locally, make
 
 3. Retrieve the values for your application's Client ID and Client Secret from the [GitHub Developer Settings page](https://github.com/settings/developers) and add them to the end of the corresponding lines in .env.
 
-## Installation
+### Docker
 
-You need to satisfy all [project requirements](#requirements), and then run:
+docker run --env-file .env --rm -p 8080:8080 srcd/code-annotation
 
-```bash
-$ go get github.com/src-d/code-annotation/...
-$ cd $GOPATH/github.com/src-d/code-annotation
-$ make serve
-```
+### Non-docker
 
-This will start a server locally, which you can access on [http://localhost:8080](http://localhost:8080)
+Download binary from [releases](https://github.com/src-d/code-annotation/releases) for your platform.
 
 ## Importing and Exporting Data
 
@@ -129,8 +103,7 @@ The annotations made by the users will be stored in the **`assignments`** table.
 
 ## Contributing
 
-[Contributions](https://github.com/src-d/code-annotation/issues) are more than welcome, if you are interested please take a look to
-our [Contributing Guidelines](CONTRIBUTING.md).
+[Contributions](https://github.com/src-d/code-annotation/issues) are more than welcome, if you are interested please take a look to our [Contributing Guidelines](CONTRIBUTING.md).
 
 # Code of Conduct
 

--- a/server/assets/asset.go
+++ b/server/assets/asset.go
@@ -1,0 +1,40 @@
+// satisfies go-bindata interface
+// this file is replaced by auto generated code for production usage
+// we use it instead of go-bindata -dev because it's easier to write wrapper
+// than change webpack configuration in create-react-app _O.O_
+
+package assets
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+// Asset loads and returns the asset for the given name.
+// It returns an error if the asset could not be found or
+// could not be loaded.
+func Asset(name string) ([]byte, error) {
+	return ioutil.ReadFile(name)
+}
+
+// MustAsset is like Asset but panics when Asset would return an error.
+// It simplifies safe initialization of global variables.
+func MustAsset(name string) []byte {
+	b, err := Asset(name)
+	if err != nil {
+		panic(fmt.Errorf("can't read file %s: %s", name, err))
+	}
+	return b
+}
+
+// AssetInfo loads and returns the asset info for the given name.
+// It returns an error if the asset could not be found or
+// could not be loaded.
+func AssetInfo(name string) (os.FileInfo, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return f.Stat()
+}


### PR DESCRIPTION
Fixes https://github.com/src-d/code-annotation/issues/34
Contains Gopkg.toml & Gopkg.yaml from https://github.com/src-d/code-annotation/pull/33

For easier understanding here is use cases:

For user:
  - CI react on a tag and run `make release` (no .travis config yet, we aren't ready for release)
  - It will produce single binary and docker image
  - binary will be uploaded to github for distribution

So, user needs:
  - download tarfile from releases
  - or use `docker run src-d/code-annotation`

For developers:

Global dependencies:
  - Go 1.9
  - Node 8
  - Yarn 1

Start contributing:
  - `go get -d -u github.com/src-d/code-annotation/...`
  - `$GOPATH/github.com/src-d/code-annotation`
  - `make serve`
  - no need for extra steps or commands before commit & push

For frontend developer who want to benefit from hot reloading:
  - `go get -d -u github.com/src-d/code-annotation/...`
  - `$GOPATH/github.com/src-d/code-annotation`
  - `make serve`
  - `make dev-frontend`

For crazy developers: (undocumented, unsupported but works)
  - `go get github.com/src-d/code-annotation/...` still works
  - but dependencies should be managed by the developer
