### PR TITLE
DB Exports in the UI

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -12,10 +12,11 @@ import (
 )
 
 type appConfig struct {
-	Host     string `envconfig:"HOST"`
-	Port     int    `envconfig:"PORT" default:"8080"`
-	UIDomain string `envconfig:"UI_DOMAIN" default:"http://127.0.0.1:8080"`
-	DBConn   string `envconfig:"DB_CONNECTION" default:"sqlite://./internal.db"`
+	Host        string `envconfig:"HOST"`
+	Port        int    `envconfig:"PORT" default:"8080"`
+	UIDomain    string `envconfig:"UI_DOMAIN" default:"http://127.0.0.1:8080"`
+	DBConn      string `envconfig:"DB_CONNECTION" default:"sqlite://./internal.db"`
+	ExportsPath string `envconfig:"EXPORTS_PATH" default:"./exports"`
 }
 
 func main() {
@@ -54,7 +55,7 @@ func main() {
 	jwt := service.NewJWT(jwtConfig.SigningKey)
 
 	// start the router
-	router := server.Router(logger, jwt, oauth, conf.UIDomain, db.SQLDB(), "build")
+	router := server.Router(logger, jwt, oauth, conf.UIDomain, &db, "build", conf.ExportsPath)
 	logger.Info("running...")
 	err = http.ListenAndServe(fmt.Sprintf("%s:%d", conf.Host, conf.Port), router)
 	logger.Fatal(err)

--- a/server/handler/exports.go
+++ b/server/handler/exports.go
@@ -1,0 +1,157 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/src-d/code-annotation/server/dbutil"
+	"github.com/src-d/code-annotation/server/service"
+)
+
+const tmpl = `
+<html>
+	<body>
+		<br/><br/>
+		<button onclick="location='create'">Create a new SQLite file</button>
+		<ul>
+		{{range .}}
+			<li><a href="file/{{.}}">{{.}}</a></li>
+		{{end}}
+		</ul>
+	</body>
+</html>`
+
+var dbConn string
+
+// InitializeExports adds the export routes to the given chi.Mux
+func InitializeExports(uiDomain string, r *chi.Mux) {
+	// This is not reusing the conf read in server.go to avoid refactoring
+	var conf struct {
+		DBConn      string `envconfig:"DB_CONNECTION" default:"sqlite://./internal.db"`
+		ExportsPath string `envconfig:"EXPORTS_PATH" default:"exports"`
+	}
+	envconfig.MustProcess("", &conf)
+
+	dbConn = conf.DBConn
+	exportsPath := conf.ExportsPath
+
+	// Create the dir to store export files
+	os.MkdirAll(exportsPath, 0775)
+
+	r.Route("/exports", func(r chi.Router) {
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			url := fmt.Sprintf("%s/%s/list", uiDomain, exportsPath)
+			http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+		})
+
+		r.Get("/list", exportList(exportsPath, true))
+		r.Get("/create", exportCreate(exportsPath, uiDomain))
+		r.Get("/file/{filename}", exportDownload(exportsPath))
+	})
+}
+
+// exportsErr sets the error message in the log and the response
+func exportsErr(err error, w http.ResponseWriter, r *http.Request) {
+	err = fmt.Errorf("exports handler error: %s", err.Error())
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+	service.NewLogger().Error(err.Error())
+}
+
+// exportList handles requests to /list
+func exportList(exportsPath string, useIndexFallback bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		files, err := ioutil.ReadDir(exportsPath)
+		if err != nil {
+			exportsErr(err, w, r)
+			return
+		}
+
+		var fileNames []string
+
+		for _, file := range files {
+			fileNames = append(fileNames, file.Name())
+		}
+
+		sort.Sort(sort.Reverse(sort.StringSlice(fileNames)))
+
+		t := template.New("export tmpl")
+		t, err = t.Parse(tmpl)
+		if err != nil {
+			exportsErr(err, w, r)
+			return
+		}
+
+		t.Execute(w, fileNames)
+	}
+}
+
+// exportCreate handles requests to /create
+func exportCreate(exportsPath string, uiDomain string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		originDB, err := dbutil.Open(dbConn, true)
+		if err != nil {
+			exportsErr(err, w, r)
+			return
+		}
+		defer originDB.Close()
+
+		filepath := fmt.Sprintf("./%s/%s-export.db",
+			exportsPath, time.Now().Format(time.RFC3339))
+
+		if _, err := os.Stat(filepath); err == nil {
+			exportsErr(errors.New("DB file already exists"), w, r)
+			return
+		}
+
+		destDB, err := dbutil.OpenSQLite(filepath, false)
+		if err != nil {
+			exportsErr(err, w, r)
+			return
+		}
+		defer destDB.Close()
+
+		if err = dbutil.Bootstrap(destDB); err != nil {
+			exportsErr(err, w, r)
+			return
+		}
+
+		if err := dbutil.Copy(originDB, destDB, dbutil.Options{}); err != nil {
+			exportsErr(err, w, r)
+			return
+		}
+
+		service.NewLogger().Info("new SQLite file created: " + filepath)
+
+		url := fmt.Sprintf("%s/%s/list", uiDomain, exportsPath)
+		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+	}
+}
+
+// exportDownload handles requests to /file/
+func exportDownload(exportsPath string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		filename := chi.URLParam(r, "filename")
+		filepath := exportsPath + "/" + filename
+
+		file, err := os.Open(filepath)
+		if err != nil {
+			exportsErr(err, w, r)
+			return
+		}
+		defer file.Close()
+
+		w.Header().Set("Content-Disposition", "attachment; filename="+filename)
+		w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
+
+		io.Copy(w, file)
+	}
+}

--- a/server/router.go
+++ b/server/router.go
@@ -71,5 +71,7 @@ func Router(
 	r.Get("/static/*", handler.FrontendStatics(staticsPath, false))
 	r.Get("/*", handler.FrontendStatics(staticsPath, true))
 
+	handler.InitializeExports(uiDomain, r)
+
 	return r
 }

--- a/server/router.go
+++ b/server/router.go
@@ -71,7 +71,7 @@ func Router(
 	r.Get("/static/*", handler.FrontendStatics(staticsPath, false))
 	r.Get("/*", handler.FrontendStatics(staticsPath, true))
 
-	handler.InitializeExports(uiDomain, r)
+	handler.InitializeExports(uiDomain, userRepo, jwt, r)
 
 	return r
 }

--- a/server/service/acl.go
+++ b/server/service/acl.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/src-d/code-annotation/server/model"
+	"github.com/src-d/code-annotation/server/repository"
+)
+
+// ACL allows to manage permissions for user role
+type ACL struct {
+	usersRepo *repository.Users
+	role      model.Role
+}
+
+// NewACL creates new ACL service
+func NewACL(usersRepo *repository.Users, role model.Role) *ACL {
+	return &ACL{
+		usersRepo: usersRepo,
+		role:      role,
+	}
+}
+
+// Middleware provides middleware which allows requests only for user only with selected role
+func (s *ACL) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, _ := GetUserID(r.Context())
+
+		user, err := s.usersRepo.GetByID(userID)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		if user == nil || user.Role != s.role {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/service/jwt.go
+++ b/server/service/jwt.go
@@ -22,8 +22,11 @@ func stripBearerPrefixFromTokenString(tok string) (string, error) {
 }
 
 var extractor = &request.PostExtractionFilter{
-	Extractor: request.HeaderExtractor{"Authorization"},
-	Filter:    stripBearerPrefixFromTokenString,
+	Extractor: &request.MultiExtractor{
+		request.HeaderExtractor{"Authorization"},
+		request.ArgumentExtractor{"jwt_token"},
+	},
+	Filter: stripBearerPrefixFromTokenString,
 }
 
 // JWTConfig defines enviroment variables for JWT

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import Index from './pages/Index';
 import Experiment from './pages/Experiment';
 import Final from './pages/Final';
 import Review from './pages/Review';
+import Export from './pages/Export';
 
 class App extends Component {
   render() {
@@ -27,6 +28,9 @@ class App extends Component {
           </Fragment>
           <Fragment forRoute={namedRoutes.review}>
             <Review />
+          </Fragment>
+          <Fragment forRoute={namedRoutes.export}>
+            <Export />
           </Fragment>
           <Fragment forNoMatch>
             <div>not found</div>

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -103,10 +103,29 @@ function putAnswer(experimentId, assignmentId, answer) {
   );
 }
 
+function exportList() {
+  return apiCall('/api/exports');
+}
+
+function exportCreate() {
+  return apiCall(`/api/exports`, {
+    method: 'POST',
+  });
+}
+
+function exportDownload(filename) {
+  const token = TokenService.get();
+  const url = apiUrl(`/api/exports/${filename}/download?jwt_token=${token}`);
+  window.open(url, '_blank');
+}
+
 export default {
   me,
   getExperiment,
   getAssignments,
   getFilePair,
   putAnswer,
+  exportList,
+  exportCreate,
+  exportDownload,
 };

--- a/src/pages/Export.js
+++ b/src/pages/Export.js
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Grid, Row, Col, Button } from 'react-bootstrap';
+import PageHeader from '../components/PageHeader';
+import Loader from '../components/Loader';
+import { add as addErrors } from '../state/errors';
+import api from '../api';
+
+class Export extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: true,
+      files: [],
+    };
+
+    this.loadFiles = this.loadFiles.bind(this);
+    this.onCreateClick = this.onCreateClick.bind(this);
+  }
+
+  componentDidMount() {
+    this.loadFiles().catch(err => {
+      this.props.addErrors(err);
+    });
+  }
+
+  loadFiles() {
+    this.setState({ loading: true });
+
+    return api
+      .exportList()
+      .then(files => {
+        this.setState({ files: files || [], loading: false });
+      })
+      .catch(err => {
+        this.setState({ loading: false });
+        throw err;
+      });
+  }
+
+  onCreateClick(e) {
+    e.preventDefault();
+
+    return api
+      .exportCreate()
+      .then(this.loadFiles)
+      .catch(err => {
+        this.props.addErrors(err);
+      });
+  }
+
+  render() {
+    return (
+      <div className="export-page">
+        <PageHeader {...this.props.user} />
+        <Grid>
+          <Row style={{ paddingTop: '20px', paddingBottom: '20px' }}>
+            <Col xs={12}>
+              <Button
+                bsStyle="primary"
+                onClick={this.onCreateClick}
+                disabled={this.state.loading}
+              >
+                Create a new SQLite export
+              </Button>
+            </Col>
+          </Row>
+          <Row>
+            <Col xs={12}>{this.filesList()}</Col>
+          </Row>
+        </Grid>
+      </div>
+    );
+  }
+
+  filesList() {
+    if (this.state.loading) {
+      return <Loader />;
+    }
+
+    if (!this.state.files.length) {
+      return <p>No files to download</p>;
+    }
+
+    return (
+      <ul>
+        {this.state.files.map((f, i) => (
+          <li key={i}>
+            <a
+              href="#"
+              onClick={e => {
+                e.preventDefault();
+                api.exportDownload(f);
+              }}
+            >
+              {f}
+            </a>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  user: state.user,
+});
+
+export default connect(mapStateToProps, { addErrors })(Export);

--- a/src/state/routes.js
+++ b/src/state/routes.js
@@ -21,6 +21,9 @@ const routes = {
     '/review': {
       name: 'review',
     },
+    '/export': {
+      name: 'export',
+    },
   },
 };
 


### PR DESCRIPTION
Implements #73.

This PR adds handlers to allow the following actions from the UI:
- export the data to a SQLite DB
- download that file

The creation and download is restricted to users with the Requester role.
To access this new route, you must visit `<hostname>/exports`

_Note_: Of course there are many things to improve. The code has been done with the intention of being a quick and basic first iteration, for a functionality that we may not want to keep.
The code is all contained in a single file for this very same reason.

![image](https://user-images.githubusercontent.com/1469173/36039696-90de387a-0dc3-11e8-99c4-3c7049934dd3.png)
