### PR TITLE
Don't expose internal error

### DIFF
--- a/server/handler/render.go
+++ b/server/handler/render.go
@@ -47,7 +47,7 @@ func write(w http.ResponseWriter, r *http.Request, response *serializer.Response
 	} else {
 		statusCode = http.StatusInternalServerError
 		response.Status = statusCode
-		response.Errors = []serializer.HTTPError{serializer.NewHTTPError(statusCode, err.Error())}
+		response.Errors = []serializer.HTTPError{serializer.NewHTTPError(statusCode, http.StatusText(statusCode))}
 	}
 
 	if statusCode >= http.StatusBadRequest {


### PR DESCRIPTION
Internal errors like errors from DB shouldn't leak to a user.