### PR TITLE
Define a persistentVolume for internal database

### DIFF
--- a/helm-charts/code-annotation/templates/deployment.yaml
+++ b/helm-charts/code-annotation/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}
     spec:
+      volumes:
+        - name: "internal-database"
+          persistentVolumeClaim:
+            claimName: {{ template "fullname" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ required "Image tag is required" .Values.image.tag }}"
@@ -41,6 +45,9 @@ spec:
                   key: jwt_signing_key
           ports:
             - containerPort: {{ .Values.service.codeAnnotation.internalPort }}
+          volumeMounts:
+            - name: internal-database
+              mountPath: {{ .Values.deployment.internalDatabasePath }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm-charts/code-annotation/templates/deployment.yaml
+++ b/helm-charts/code-annotation/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
           env:
             - name: UI_DOMAIN
               value: "//{{ .Values.ingress.hostname }}"
+            - name: DB_CONNECTION
+              value: "sqlite://{{ .Values.deployment.internalDatabasePath }}/internal.db"
             - name: OAUTH_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/helm-charts/code-annotation/templates/persistent-volume-claim.yaml
+++ b/helm-charts/code-annotation/templates/persistent-volume-claim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/helm-charts/code-annotation/values.yaml
+++ b/helm-charts/code-annotation/values.yaml
@@ -10,6 +10,8 @@ image:
   repository: docker.io/srcd/code-annotation
   # tag must be received as a parameter
   pullPolicy: IfNotPresent
+deployment:
+    internalDatabasePath: /var/code-annotation
 service:
   type: NodePort
   codeAnnotation:


### PR DESCRIPTION
This PR only prepares the volume where the sqlite should be `scp`ed (the app will be prepared in a separated PR)
As I was talking with @rporres we're not still supporting Postgresql in staging but sqlite.

After this PR is merged, it will be needed to push a sqlite bd into the volume as described by https://github.com/src-d/issues-infrastructure/issues/129