### PR TITLE
Restrict access to org:src-d members

### DIFF
--- a/helm-charts/code-annotation/templates/deployment.yaml
+++ b/helm-charts/code-annotation/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ required "Image tag is required" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: OAUTH_RESTRICT_ACCESS
+              value: "{{ .Values.authorization.restrictAccessGroup }}"
+            - name: OAUTH_RESTRICT_REQUESTER_ACCESS
+              value: "{{ .Values.authorization.restrictRequesterGroup }}"
             - name: UI_DOMAIN
               value: "//{{ .Values.ingress.hostname }}"
             - name: DB_CONNECTION

--- a/helm-charts/code-annotation/values.yaml
+++ b/helm-charts/code-annotation/values.yaml
@@ -11,7 +11,10 @@ image:
   # tag must be received as a parameter
   pullPolicy: IfNotPresent
 deployment:
-    internalDatabasePath: /var/code-annotation
+    internalDatabasePath: "/var/code-annotation"
+authorization:
+    restrictAccessGroup: "org:src-d"
+    restrictRequesterGroup: ""
 service:
   type: NodePort
   codeAnnotation:


### PR DESCRIPTION
Only members of `src-d` will be accepted as valid users.
(the org can be configured during the deploy)