### PR TITLE
Add role restrictions to routes

### DIFF
--- a/server/model/models.go
+++ b/server/model/models.go
@@ -70,6 +70,11 @@ type Feature struct {
 // Role represents the position of a app User
 type Role string
 
+// String returns the string value of the Role
+func (r Role) String() string {
+	return string(r)
+}
+
 // Value returns the string value of the Role
 func (r Role) Value() (driver.Value, error) {
 	if isValidRole(r) {

--- a/server/router.go
+++ b/server/router.go
@@ -72,17 +72,20 @@ func Router(
 			})
 
 			r.Route("/file-pairs", func(r chi.Router) {
+				r.Use(requesterACL.Middleware)
+
 				r.Get("/", handler.Get(handler.GetFilePairs(filePairRepo)))
-
-				r.Route("/{pairId}", func(r chi.Router) {
-					r.Get("/", handler.Get(handler.GetFilePairDetails(filePairRepo)))
-					r.Get("/annotations", handler.Get(handler.GetFilePairAnnotations(assignmentRepo)))
-				})
-
+				r.Get("/{pairId}/annotations", handler.Get(handler.GetFilePairAnnotations(assignmentRepo)))
 			})
+
+			r.Get("/file-pairs/{pairId}", handler.Get(handler.GetFilePairDetails(filePairRepo)))
 		})
 
-		r.Get("/features/{blobId}", handler.Get(handler.GetFeatures(featureRepo)))
+		r.Route("/features", func(r chi.Router) {
+			r.Use(requesterACL.Middleware)
+
+			r.Get("/{blobId}", handler.Get(handler.GetFeatures(featureRepo)))
+		})
 
 		r.Route("/exports", func(r chi.Router) {
 			r.Use(requesterACL.Middleware)

--- a/server/serializer/serializers.go
+++ b/server/serializer/serializers.go
@@ -159,11 +159,13 @@ type userResponse struct {
 	Login     string `json:"login"`
 	Username  string `json:"username"`
 	AvatarURL string `json:"avatarURL"`
+	Role      string `json:"role"`
 }
 
 // NewUserResponse returns a Response for the passed User
 func NewUserResponse(u *model.User) *Response {
-	return newResponse(userResponse{u.ID, u.Login, u.Username, u.AvatarURL})
+	return newResponse(
+		userResponse{u.ID, u.Login, u.Username, u.AvatarURL, u.Role.String()})
 }
 
 type featureResponse struct {

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Experiment from './pages/Experiment';
 import Final from './pages/Final';
 import Review from './pages/Review';
 import Export from './pages/Export';
+import Forbidden from './pages/Forbidden';
 
 class App extends Component {
   render() {
@@ -33,6 +34,9 @@ class App extends Component {
           </Fragment>
           <Fragment forRoute={namedRoutes.export}>
             <Export />
+          </Fragment>
+          <Fragment forRoute={namedRoutes.forbidden}>
+            <Forbidden />
           </Fragment>
           <Fragment forNoMatch>
             <div>not found</div>

--- a/src/pages/Forbidden.js
+++ b/src/pages/Forbidden.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Grid, Row, Col } from 'react-bootstrap';
+import PageHeader from '../components/PageHeader';
+
+class Forbidden extends Component {
+  render() {
+    return (
+      <div className="forbidden-page">
+        <PageHeader {...this.props.user} />
+        <Grid>
+          <Row style={{ paddingTop: '20px', paddingBottom: '20px' }}>
+            <Col xs={12}>
+              <p>
+                You tried to perform an action you are not currently authorized
+                to do.
+              </p>
+            </Col>
+          </Row>
+        </Grid>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  user: state.user,
+});
+
+export default connect(mapStateToProps)(Forbidden);

--- a/src/state/routes.js
+++ b/src/state/routes.js
@@ -16,8 +16,10 @@ const routes = {
       },
       '/review': {
         name: 'review',
+        restrictReviewer: true,
         '/:pair': {
           name: 'reviewPair',
+          restrictReviewer: true,
         },
       },
       '/:question': {
@@ -26,6 +28,10 @@ const routes = {
     },
     '/export': {
       name: 'export',
+      restrictReviewer: true,
+    },
+    '/forbidden': {
+      name: 'forbidden',
     },
   },
 };

--- a/src/state/user.js
+++ b/src/state/user.js
@@ -22,6 +22,7 @@ const reducer = (state = initialState, action) => {
         userId: action.userId,
         username: action.username,
         avatarUrl: action.avatarUrl,
+        role: action.role,
       };
     case LOG_OUT: {
       return initialState;
@@ -44,9 +45,10 @@ export const logIn = () => dispatch =>
     .then(resp => {
       dispatch({
         type: LOG_IN,
-        userId: resp.userId,
+        userId: resp.id,
         username: resp.username,
         avatarUrl: resp.avatarURL,
+        role: resp.role,
       });
     })
     .catch(e => {
@@ -76,6 +78,10 @@ export const authMiddleware = store => next => action => {
       // redirect user from index page to experiment if user it authorized already
       if (user.loggedIn && result && result.name === 'index') {
         return next(push('/exp/1'));
+      }
+      // hide pages that are meant only for users with the requester role
+      if (user.role !== 'requester' && result && result.restrictReviewer) {
+        return next(replace('/forbidden'));
       }
       return next(action);
     })


### PR DESCRIPTION
Part of #47. This PR adds authorization restrictions based on the user role.

In the backend the server replies with an unathorized response.
In the frontend a restricted route redirects to a new page, `unauthorized`, that shows a simple information message.

![127 0 0 1_3000_export](https://user-images.githubusercontent.com/1469173/36265582-d0ebd584-126f-11e8-9f98-8a7be3b131f0.png)