### PR TITLE
CI check for correct vendor dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
   # uncommend next line when BE code will start passing go lint and go vet
   # - make lint-backend
   - make test
+  - make validate-commit

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ bindata:
 
 prepare-build: | build-frontend build-backend bindata
 
+validate-commit: dependencies-backend no-changes-in-commit
+
 # Run only server
 gorun:
 	go run cli/server/server.go


### PR DESCRIPTION
Fixes: https://github.com/src-d/code-annotation/issues/40

It just checks git status after `dep ensure`.