### PR TITLE
Fix .env export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ $(MAKEFILE):
 -include $(MAKEFILE)
 
 # Set enviroment variables from .env file
-ENV ?= .env
--include $(ENV)
-export $(shell [ -f "$(ENV)" ] && sed 's/=.*//' $(ENV))
+DOT_ENV ?= .env
+-include $(DOT_ENV)
+export $(shell [ -f "$(DOT_ENV)" ] && sed 's/=.*//' $(DOT_ENV))
 
 
 # Frontend


### PR DESCRIPTION
blocks #141

Rename `ENV` env var name because it is already used https://github.com/src-d/code-annotation/blob/master/.env.tpl#L4