### PR TITLE
Implement page with a list of experiments

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet';
 import { namedRoutes } from './state/routes';
 import Errors from './components/Errors';
 import Index from './pages/Index';
+import Experiments from './pages/Experiments';
 import Experiment from './pages/Experiment';
 import Final from './pages/Final';
 import Review from './pages/Review';
@@ -19,6 +20,9 @@ class App extends Component {
           <Errors />
           <Fragment forRoute={namedRoutes.index}>
             <Index />
+          </Fragment>
+          <Fragment forRoute={namedRoutes.dashboard}>
+            <Experiments />
           </Fragment>
           <Fragment forRoute={namedRoutes.finish}>
             <Final />

--- a/src/components/ExperimentsList.js
+++ b/src/components/ExperimentsList.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Table, Button } from 'react-bootstrap';
+import './ExperimentsList.less';
+
+function buttonText(procent) {
+  switch (procent) {
+    case 0:
+      return 'Begin';
+    case 100:
+      return 'Finished';
+    default:
+      return 'Continue';
+  }
+}
+
+function ExperimentsList({ experiments }) {
+  return (
+    <Table responsive className="experiments-list">
+      <tbody>
+        {experiments.map(exp => {
+          const started = exp.procent === 0;
+          const finished = exp.procent === 100;
+          return (
+            <tr
+              key={exp.id}
+              className={`experiments-list__row${finished ? ' finished' : ''}`}
+            >
+              <td className="experiments-list__name">{exp.name}</td>
+              <td className="experiments-list__procent">{exp.procent}%</td>
+              <td className="experiments-list__additional-actions">
+                {!finished && !started ? (
+                  <a href="#">mark as finished</a>
+                ) : null}
+              </td>
+              <td className="experiments-list__actions">
+                <Button bsStyle="primary" bsSize="xsmall" disabled={finished}>
+                  {buttonText(exp.procent)}
+                </Button>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </Table>
+  );
+}
+
+export default ExperimentsList;

--- a/src/components/ExperimentsList.js
+++ b/src/components/ExperimentsList.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { Table, Button } from 'react-bootstrap';
 import './ExperimentsList.less';
 
-function buttonText(procent) {
-  switch (procent) {
+function buttonText(percent) {
+  switch (percent) {
     case 0:
       return 'Begin';
     case 100:
@@ -18,23 +18,23 @@ function ExperimentsList({ experiments }) {
     <Table responsive className="experiments-list">
       <tbody>
         {experiments.map(exp => {
-          const started = exp.procent === 0;
-          const finished = exp.procent === 100;
+          const started = exp.percent === 0;
+          const finished = exp.percent === 100;
           return (
             <tr
               key={exp.id}
               className={`experiments-list__row${finished ? ' finished' : ''}`}
             >
               <td className="experiments-list__name">{exp.name}</td>
-              <td className="experiments-list__procent">{exp.procent}%</td>
+              <td className="experiments-list__percent">{exp.percent}%</td>
               <td className="experiments-list__additional-actions">
                 {!finished && !started ? (
-                  <a href="#">mark as finished</a>
+                  <a href="/">mark as finished</a>
                 ) : null}
               </td>
               <td className="experiments-list__actions">
                 <Button bsStyle="primary" bsSize="xsmall" disabled={finished}>
-                  {buttonText(exp.procent)}
+                  {buttonText(exp.percent)}
                 </Button>
               </td>
             </tr>

--- a/src/components/ExperimentsList.less
+++ b/src/components/ExperimentsList.less
@@ -18,7 +18,7 @@
         white-space: nowrap;
     }
 
-    &__procent {
+    &__percent {
         font-size: 16px;
         border-left: 1px solid @table-border-color;
     }

--- a/src/components/ExperimentsList.less
+++ b/src/components/ExperimentsList.less
@@ -1,0 +1,38 @@
+@import '../../node_modules/bootstrap/less/variables.less';
+
+.experiments-list {
+    &__actions {
+        text-align: center;
+    }
+
+    td {
+        vertical-align: middle !important;
+    }
+
+    tr:first-child > td {
+        border-top: 0;
+    }
+
+    &__name {
+        font-size: 16px;
+        white-space: nowrap;
+    }
+
+    &__procent {
+        font-size: 16px;
+        border-left: 1px solid @table-border-color;
+    }
+
+    &__additional-actions {
+        width: 100%;
+        text-align: right;
+    }
+
+    &__row.finished {
+        color: #ccc;
+    }
+
+    .btn {
+        width: 140px;
+    }
+}

--- a/src/pages/Experiments.js
+++ b/src/pages/Experiments.js
@@ -5,7 +5,7 @@ import { Helmet } from 'react-helmet';
 import PageHeader from '../components/PageHeader';
 import ExperimentsList from '../components/ExperimentsList';
 
-class Final extends Component {
+class Experiments extends Component {
   render() {
     const { user, experiments } = this.props;
 
@@ -45,10 +45,10 @@ class Final extends Component {
 const mapStateToProps = state => ({
   user: state.user,
   experiments: [
-    { id: 1, name: 'Lee Morgan Experiment', procent: 0 },
-    { id: 2, name: 'Chet Baker Experiment', procent: 36 },
-    { id: 2, name: 'Cliff Brown Experiment', procent: 100 },
+    { id: 1, name: 'Lee Morgan Experiment', percent: 0 },
+    { id: 2, name: 'Chet Baker Experiment', percent: 36 },
+    { id: 2, name: 'Cliff Brown Experiment', percent: 100 },
   ],
 });
 
-export default connect(mapStateToProps)(Final);
+export default connect(mapStateToProps)(Experiments);

--- a/src/pages/Experiments.js
+++ b/src/pages/Experiments.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Grid, Row, Col } from 'react-bootstrap';
+import { Helmet } from 'react-helmet';
+import PageHeader from '../components/PageHeader';
+import ExperimentsList from '../components/ExperimentsList';
+
+class Final extends Component {
+  render() {
+    const { user, experiments } = this.props;
+
+    return (
+      <div className="experiments-page">
+        <Helmet>
+          <title>Experiments</title>
+        </Helmet>
+        <PageHeader />
+        <Grid>
+          <Row>
+            <Col xs={12}>
+              <h1 className="text-center">
+                You look great today, {user.username}!
+              </h1>
+            </Col>
+          </Row>
+          <Row>
+            <Col xs={12}>
+              <p className="text-center">
+                Here&#39;s your experiments dashboard, go ahead and make our
+                day.
+              </p>
+            </Col>
+          </Row>
+          <Row>
+            <Col xs={8} xsOffset={2} style={{ paddingTop: '40px' }}>
+              <ExperimentsList experiments={experiments} />
+            </Col>
+          </Row>
+        </Grid>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  user: state.user,
+  experiments: [
+    { id: 1, name: 'Lee Morgan Experiment', procent: 0 },
+    { id: 2, name: 'Chet Baker Experiment', procent: 36 },
+    { id: 2, name: 'Cliff Brown Experiment', procent: 100 },
+  ],
+});
+
+export default connect(mapStateToProps)(Final);

--- a/src/state/routes.js
+++ b/src/state/routes.js
@@ -9,6 +9,9 @@ const routes = {
   '/': {
     name: 'index',
     public: true,
+    '/dashboard': {
+      name: 'dashboard',
+    },
     '/exp/:experiment': {
       name: 'experiment',
       '/finish': {


### PR DESCRIPTION
Implements the first point in https://github.com/src-d/code-annotation/issues/149

<img width="1322" alt="screen shot 2018-02-21 at 17 24 48" src="https://user-images.githubusercontent.com/406916/36491902-2c003396-172c-11e8-97d3-8a6926941e5b.png">

The page is available by url `/dashboard`.