### PR TITLE
Add new route /experiments

### DIFF
--- a/server/handler/experiments.go
+++ b/server/handler/experiments.go
@@ -28,3 +28,16 @@ func GetExperimentDetails(repo *repository.Experiments) RequestProcessFunc {
 		return serializer.NewExperimentResponse(experiment), nil
 	}
 }
+
+// GetExperiments returns a function that returns a *serializer.Response
+// with the list of existing experiments
+func GetExperiments(repo *repository.Experiments) RequestProcessFunc {
+	return func(r *http.Request) (*serializer.Response, error) {
+		experiments, err := repo.GetAll()
+		if err != nil {
+			return nil, err
+		}
+
+		return serializer.NewExperimentsResponse(experiments), nil
+	}
+}

--- a/server/router.go
+++ b/server/router.go
@@ -61,6 +61,8 @@ func Router(
 
 		r.Get("/me", handler.Get(handler.Me(userRepo)))
 
+		r.Get("/experiments", handler.Get(handler.GetExperiments(experimentRepo)))
+
 		r.Route("/experiments/{experimentId}", func(r chi.Router) {
 
 			r.Get("/", handler.Get(handler.GetExperimentDetails(experimentRepo)))

--- a/server/serializer/serializers.go
+++ b/server/serializer/serializers.go
@@ -82,6 +82,20 @@ func NewExperimentResponse(e *model.Experiment) *Response {
 	})
 }
 
+// NewExperimentsResponse returns a Response with a list of Experiments
+func NewExperimentsResponse(experiments []*model.Experiment) *Response {
+	result := make([]experimentResponse, len(experiments))
+	for i, e := range experiments {
+		result[i] = experimentResponse{
+			ID:          e.ID,
+			Name:        e.Name,
+			Description: e.Description,
+		}
+	}
+
+	return newResponse(result)
+}
+
 type assignmentResponse struct {
 	ID           int     `json:"id"`
 	UserID       int     `json:"userId"`


### PR DESCRIPTION
Implements functionality for #149.

The new route lists all the existing experiments for logged-in users.