### PR TITLE
Connect experiments page

### DIFF
--- a/server/handler/experiments.go
+++ b/server/handler/experiments.go
@@ -1,16 +1,23 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/src-d/code-annotation/server/repository"
 	"github.com/src-d/code-annotation/server/serializer"
+	"github.com/src-d/code-annotation/server/service"
 )
 
 // GetExperimentDetails returns a function that returns a *serializer.Response
 // with the details of a requested experiment
-func GetExperimentDetails(repo *repository.Experiments) RequestProcessFunc {
+func GetExperimentDetails(repo *repository.Experiments, assignmentsRepo *repository.Assignments) RequestProcessFunc {
 	return func(r *http.Request) (*serializer.Response, error) {
+		userID, err := service.GetUserID(r.Context())
+		if err != nil {
+			return nil, err
+		}
+
 		experimentID, err := urlParamInt(r, "experimentId")
 		if err != nil {
 			return nil, err
@@ -25,19 +32,52 @@ func GetExperimentDetails(repo *repository.Experiments) RequestProcessFunc {
 			return nil, serializer.NewHTTPError(http.StatusNotFound, "no experiment found")
 		}
 
-		return serializer.NewExperimentResponse(experiment), nil
+		progress, err := experimentProgress(assignmentsRepo, experiment.ID, userID)
+		if err != nil {
+			return nil, err
+		}
+
+		return serializer.NewExperimentResponse(experiment, progress), nil
 	}
 }
 
 // GetExperiments returns a function that returns a *serializer.Response
 // with the list of existing experiments
-func GetExperiments(repo *repository.Experiments) RequestProcessFunc {
+func GetExperiments(repo *repository.Experiments, assignmentsRepo *repository.Assignments) RequestProcessFunc {
 	return func(r *http.Request) (*serializer.Response, error) {
+		userID, err := service.GetUserID(r.Context())
+		if err != nil {
+			return nil, err
+		}
+
 		experiments, err := repo.GetAll()
 		if err != nil {
 			return nil, err
 		}
 
-		return serializer.NewExperimentsResponse(experiments), nil
+		var progresses []float32
+		for _, e := range experiments {
+			progress, err := experimentProgress(assignmentsRepo, e.ID, userID)
+			if err != nil {
+				return nil, err
+			}
+			progresses = append(progresses, progress)
+		}
+
+		return serializer.NewExperimentsResponse(experiments, progresses), nil
 	}
+}
+
+func experimentProgress(repo *repository.Assignments, experimentID int, userID int) (float32, error) {
+	countAll, err := repo.CountUserAssigments(experimentID, userID)
+	if err != nil {
+		return 0, fmt.Errorf("Error count of assigments from the DB: %v", err)
+	}
+
+	countComplete, err := repo.CountCompleteUserAssigments(experimentID, userID)
+	if err != nil {
+		return 0, fmt.Errorf("Error count of complete assigments from the DB: %v", err)
+	}
+
+	return 100.0 * float32(countComplete) / float32(countAll), nil
 }

--- a/server/handler/experiments.go
+++ b/server/handler/experiments.go
@@ -69,12 +69,12 @@ func GetExperiments(repo *repository.Experiments, assignmentsRepo *repository.As
 }
 
 func experimentProgress(repo *repository.Assignments, experimentID int, userID int) (float32, error) {
-	countAll, err := repo.CountUserAssigments(experimentID, userID)
+	countAll, err := repo.CountUserAssignment(experimentID, userID)
 	if err != nil {
 		return 0, fmt.Errorf("Error count of assigments from the DB: %v", err)
 	}
 
-	countComplete, err := repo.CountCompleteUserAssigments(experimentID, userID)
+	countComplete, err := repo.CountCompleteUserAssignment(experimentID, userID)
 	if err != nil {
 		return 0, fmt.Errorf("Error count of complete assigments from the DB: %v", err)
 	}

--- a/server/handler/experiments.go
+++ b/server/handler/experiments.go
@@ -79,5 +79,9 @@ func experimentProgress(repo *repository.Assignments, experimentID int, userID i
 		return 0, fmt.Errorf("Error count of complete assigments from the DB: %v", err)
 	}
 
+	if countAll == 0 {
+		return 0, nil
+	}
+
 	return 100.0 * float32(countComplete) / float32(countAll), nil
 }

--- a/server/repository/assignments.go
+++ b/server/repository/assignments.go
@@ -24,8 +24,8 @@ const (
 	selectAssignmentsWhereExpPairSQL = `SELECT * FROM assignments WHERE experiment_id=$1 AND pair_id=$2`
 	updateAssignmentsSQL             = `UPDATE assignments SET answer='%v', duration=%v WHERE id=%v`
 	countPendingIDsSQL               = `SELECT count(id) FROM file_pairs WHERE experiment_id=$1 AND id NOT IN (SELECT pair_id FROM assignments WHERE experiment_id=$1 AND user_id=$2)`
-	countUserAssigmentsSQL           = `SELECT COUNT(*) FROM assignments WHERE experiment_id=$1 AND user_id=$1`
-	countCompleteUserAssigmentsSQL   = `SELECT COUNT(*) FROM assignments WHERE experiment_id=$1 AND user_id=$1 AND answer IS NOT null`
+	countUserAssigmentsSQL           = `SELECT COUNT(*) FROM assignments WHERE experiment_id=$1 AND user_id=$2`
+	countCompleteUserAssigmentsSQL   = `SELECT COUNT(*) FROM assignments WHERE experiment_id=$1 AND user_id=$2 AND answer IS NOT null`
 )
 
 // IsInitialized returns true if the assignments are initialized for the given
@@ -155,8 +155,8 @@ func (repo *Assignments) Update(assignmentID int, answer string, duration int) e
 	return err
 }
 
-// CountUserAssigments returns number of assigments in given experiment for the given user
-func (repo *Assignments) CountUserAssigments(experimentID, userID int) (int, error) {
+// CountUserAssignment returns number of assigments in given experiment for the given user
+func (repo *Assignments) CountUserAssignment(experimentID, userID int) (int, error) {
 	row := repo.db.QueryRow(countUserAssigmentsSQL, experimentID, userID)
 
 	var count int
@@ -167,8 +167,8 @@ func (repo *Assignments) CountUserAssigments(experimentID, userID int) (int, err
 	return count, nil
 }
 
-// CountCompleteUserAssigments returns number of assigments with an answer in given experiment for the given user
-func (repo *Assignments) CountCompleteUserAssigments(experimentID, userID int) (int, error) {
+// CountCompleteUserAssignment returns number of assigments with an answer in given experiment for the given user
+func (repo *Assignments) CountCompleteUserAssignment(experimentID, userID int) (int, error) {
 	row := repo.db.QueryRow(countCompleteUserAssigmentsSQL, experimentID, userID)
 
 	var count int

--- a/server/repository/assignments.go
+++ b/server/repository/assignments.go
@@ -24,6 +24,8 @@ const (
 	selectAssignmentsWhereExpPairSQL = `SELECT * FROM assignments WHERE experiment_id=$1 AND pair_id=$2`
 	updateAssignmentsSQL             = `UPDATE assignments SET answer='%v', duration=%v WHERE id=%v`
 	countPendingIDsSQL               = `SELECT count(id) FROM file_pairs WHERE experiment_id=$1 AND id NOT IN (SELECT pair_id FROM assignments WHERE experiment_id=$1 AND user_id=$2)`
+	countUserAssigmentsSQL           = `SELECT COUNT(*) FROM assignments WHERE experiment_id=$1 AND user_id=$1`
+	countCompleteUserAssigmentsSQL   = `SELECT COUNT(*) FROM assignments WHERE experiment_id=$1 AND user_id=$1 AND answer IS NOT null`
 )
 
 // IsInitialized returns true if the assignments are initialized for the given
@@ -151,4 +153,28 @@ func (repo *Assignments) Update(assignmentID int, answer string, duration int) e
 	_, err := repo.db.Exec(cmd)
 
 	return err
+}
+
+// CountUserAssigments returns number of assigments in given experiment for the given user
+func (repo *Assignments) CountUserAssigments(experimentID, userID int) (int, error) {
+	row := repo.db.QueryRow(countUserAssigmentsSQL, experimentID, userID)
+
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// CountCompleteUserAssigments returns number of assigments with an answer in given experiment for the given user
+func (repo *Assignments) CountCompleteUserAssigments(experimentID, userID int) (int, error) {
+	row := repo.db.QueryRow(countCompleteUserAssigmentsSQL, experimentID, userID)
+
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return 0, err
+	}
+
+	return count, nil
 }

--- a/server/repository/experiments.go
+++ b/server/repository/experiments.go
@@ -9,12 +9,13 @@ import (
 
 // Experiments repository
 type Experiments struct {
-	db *sql.DB
+	db          *sql.DB
+	assignments *Assignments
 }
 
 // NewExperiments returns a new Experiments repository
 func NewExperiments(db *sql.DB) *Experiments {
-	return &Experiments{db: db}
+	return &Experiments{db: db, assignments: NewAssignments(db)}
 }
 
 // getWithQuery builds an Experiment from the given sql QueryRow. If the
@@ -24,14 +25,14 @@ func (repo *Experiments) getWithQuery(queryRow scannable) (*model.Experiment, er
 
 	err := queryRow.Scan(&exp.ID, &exp.Name, &exp.Description)
 
-	switch {
-	case err == sql.ErrNoRows:
+	if err == sql.ErrNoRows {
 		return nil, nil
-	case err != nil:
-		return nil, fmt.Errorf("Error getting experiment from the DB: %v", err)
-	default:
-		return &exp, nil
 	}
+	if err != nil {
+		return nil, fmt.Errorf("Error getting experiment from the DB: %v", err)
+	}
+
+	return &exp, nil
 }
 
 const selectExperimentsWhereIDSQL = `SELECT * FROM experiments WHERE id=$1`

--- a/server/router.go
+++ b/server/router.go
@@ -61,11 +61,11 @@ func Router(
 
 		r.Get("/me", handler.Get(handler.Me(userRepo)))
 
-		r.Get("/experiments", handler.Get(handler.GetExperiments(experimentRepo)))
+		r.Get("/experiments", handler.Get(handler.GetExperiments(experimentRepo, assignmentRepo)))
 
 		r.Route("/experiments/{experimentId}", func(r chi.Router) {
 
-			r.Get("/", handler.Get(handler.GetExperimentDetails(experimentRepo)))
+			r.Get("/", handler.Get(handler.GetExperimentDetails(experimentRepo, assignmentRepo)))
 
 			r.Route("/assignments", func(r chi.Router) {
 

--- a/server/serializer/serializers.go
+++ b/server/serializer/serializers.go
@@ -68,28 +68,31 @@ func NewEmptyResponse() *Response {
 }
 
 type experimentResponse struct {
-	ID          int    `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	ID          int     `json:"id"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Progress    float32 `json:"progress"`
 }
 
 // NewExperimentResponse returns a Response for the passed Experiment
-func NewExperimentResponse(e *model.Experiment) *Response {
+func NewExperimentResponse(e *model.Experiment, progress float32) *Response {
 	return newResponse(experimentResponse{
 		ID:          e.ID,
 		Name:        e.Name,
 		Description: e.Description,
+		Progress:    progress,
 	})
 }
 
 // NewExperimentsResponse returns a Response with a list of Experiments
-func NewExperimentsResponse(experiments []*model.Experiment) *Response {
+func NewExperimentsResponse(experiments []*model.Experiment, progresses []float32) *Response {
 	result := make([]experimentResponse, len(experiments))
 	for i, e := range experiments {
 		result[i] = experimentResponse{
 			ID:          e.ID,
 			Name:        e.Name,
 			Description: e.Description,
+			Progress:    progresses[i],
 		}
 	}
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -80,6 +80,10 @@ function me() {
   return apiCall(`/api/me`);
 }
 
+function getExperiments() {
+  return apiCall(`/api/experiments`);
+}
+
 function getExperiment(experimentId) {
   return apiCall(`/api/experiments/${experimentId}`);
 }
@@ -134,6 +138,7 @@ function exportDownload(filename) {
 
 export default {
   me,
+  getExperiments,
   getExperiment,
   getAssignments,
   getFilePair,

--- a/src/components/ExperimentsList.js
+++ b/src/components/ExperimentsList.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Table, Button } from 'react-bootstrap';
+import { makeUrl } from '../state/routes';
 import './ExperimentsList.less';
 
-function buttonText(percent) {
-  switch (percent) {
+function buttonText(progress) {
+  switch (progress) {
     case 0:
       return 'Begin';
     case 100:
@@ -18,23 +19,32 @@ function ExperimentsList({ experiments }) {
     <Table responsive className="experiments-list">
       <tbody>
         {experiments.map(exp => {
-          const started = exp.percent === 0;
-          const finished = exp.percent === 100;
+          // const started = exp.progress === 0;
+          const finished = exp.progress === 100;
           return (
             <tr
               key={exp.id}
               className={`experiments-list__row${finished ? ' finished' : ''}`}
             >
               <td className="experiments-list__name">{exp.name}</td>
-              <td className="experiments-list__percent">{exp.percent}%</td>
+              <td className="experiments-list__progress">
+                {Math.round(exp.progress)}%
+              </td>
               <td className="experiments-list__additional-actions">
-                {!finished && !started ? (
-                  <a href="/">mark as finished</a>
-                ) : null}
+                {/*
+                  {!finished && !started ? (
+                      <a href="/">mark as finished</a>
+                    ) : null}
+                */}
               </td>
               <td className="experiments-list__actions">
-                <Button bsStyle="primary" bsSize="xsmall" disabled={finished}>
-                  {buttonText(exp.percent)}
+                <Button
+                  bsStyle="primary"
+                  bsSize="xsmall"
+                  disabled={finished}
+                  href={makeUrl('experiment', { experiment: exp.id })}
+                >
+                  {buttonText(exp.progress)}
                 </Button>
               </td>
             </tr>

--- a/src/components/ExperimentsList.less
+++ b/src/components/ExperimentsList.less
@@ -18,7 +18,7 @@
         white-space: nowrap;
     }
 
-    &__percent {
+    &__progress {
         font-size: 16px;
         border-left: 1px solid @table-border-color;
     }

--- a/src/pages/Experiments.js
+++ b/src/pages/Experiments.js
@@ -3,52 +3,80 @@ import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-bootstrap';
 import { Helmet } from 'react-helmet';
 import PageHeader from '../components/PageHeader';
+import Loader from '../components/Loader';
 import ExperimentsList from '../components/ExperimentsList';
+import { load as experimentsLoad } from '../state/experiments';
 
 class Experiments extends Component {
-  render() {
-    const { user, experiments } = this.props;
+  componentDidMount() {
+    this.props.load();
+  }
 
+  render() {
     return (
       <div className="experiments-page">
         <Helmet>
           <title>Experiments</title>
         </Helmet>
         <PageHeader />
-        <Grid>
-          <Row>
-            <Col xs={12}>
-              <h1 className="text-center">
-                You look great today, {user.username}!
-              </h1>
-            </Col>
-          </Row>
-          <Row>
-            <Col xs={12}>
-              <p className="text-center">
-                Here&#39;s your experiments dashboard, go ahead and make our
-                day.
-              </p>
-            </Col>
-          </Row>
-          <Row>
-            <Col xs={8} xsOffset={2} style={{ paddingTop: '40px' }}>
-              <ExperimentsList experiments={experiments} />
-            </Col>
-          </Row>
-        </Grid>
+        <Grid>{this.renderContent()}</Grid>
       </div>
+    );
+  }
+
+  renderContent() {
+    const { user, experiments } = this.props;
+    const { error, loading, list } = experiments;
+
+    if (error) {
+      return (
+        <Row className="ex-page__oops">
+          <Col xs={12}>
+            Oops.<br />Something went wrong.
+          </Col>
+        </Row>
+      );
+    }
+
+    if (loading) {
+      return (
+        <Row className="ex-page__loader">
+          <Col xs={12}>
+            <Loader />
+          </Col>
+        </Row>
+      );
+    }
+
+    return (
+      <React.Fragment>
+        <Row>
+          <Col xs={12}>
+            <h1 className="text-center">
+              You look great today, {user.username}!
+            </h1>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12}>
+            <p className="text-center">
+              Here&#39;s your experiments dashboard, go ahead and make our day.
+            </p>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={8} xsOffset={2} style={{ paddingTop: '40px' }}>
+            <ExperimentsList experiments={list} />
+          </Col>
+        </Row>
+      </React.Fragment>
     );
   }
 }
 
 const mapStateToProps = state => ({
   user: state.user,
-  experiments: [
-    { id: 1, name: 'Lee Morgan Experiment', percent: 0 },
-    { id: 2, name: 'Chet Baker Experiment', percent: 36 },
-    { id: 2, name: 'Cliff Brown Experiment', percent: 100 },
-  ],
+  experiments: state.experiments,
 });
 
-export default connect(mapStateToProps)(Experiments);
+export default connect(mapStateToProps, { load: experimentsLoad })(Experiments);

--- a/src/state/__snapshots__/experiment.test.js.snap
+++ b/src/state/__snapshots__/experiment.test.js.snap
@@ -12,7 +12,6 @@ Object {
 exports[`experiment/reducer LOAD_ERROR 1`] = `
 Object {
   "error": "test error",
-  "fileLoading": false,
   "id": null,
   "loading": false,
   "name": null,

--- a/src/state/__snapshots__/experiments.test.js.snap
+++ b/src/state/__snapshots__/experiments.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`experiments/reducer LOAD 1`] = `
+Object {
+  "error": null,
+  "list": Array [],
+  "loading": true,
+}
+`;
+
+exports[`experiments/reducer LOAD_ERROR 1`] = `
+Object {
+  "error": "test error",
+  "list": Array [],
+  "loading": false,
+}
+`;
+
+exports[`experiments/reducer LOAD_SUCCESS 1`] = `
+Object {
+  "error": null,
+  "list": Array [],
+  "loading": false,
+}
+`;
+
+exports[`experiments/reducer SET 1`] = `
+Object {
+  "error": null,
+  "list": Array [
+    Object {
+      "some": "data",
+    },
+  ],
+  "loading": true,
+}
+`;

--- a/src/state/experiment.js
+++ b/src/state/experiment.js
@@ -34,7 +34,6 @@ const reducer = (state = initialState, action) => {
       return {
         ...state,
         loading: false,
-        fileLoading: false,
         error: action.error,
       };
     case SET_EXPERIMENT:

--- a/src/state/experiment.test.js
+++ b/src/state/experiment.test.js
@@ -32,7 +32,7 @@ describe('experiment/reducer', () => {
   it('LOAD_ERROR', () => {
     expect(
       reducer(
-        { ...initialState, loading: true, fileLoading: true },
+        { ...initialState, loading: true },
         { type: LOAD_ERROR, error: 'test error' }
       )
     ).toMatchSnapshot();

--- a/src/state/experiments.js
+++ b/src/state/experiments.js
@@ -1,0 +1,63 @@
+import api from '../api';
+import { add as addErrors } from './errors';
+
+/* reducer */
+
+export const initialState = {
+  loading: true,
+  error: null,
+
+  list: [],
+};
+
+export const LOAD = 'ca/experiments/LOAD';
+export const LOAD_SUCCESS = 'ca/experiments/LOAD_SUCCESS';
+export const LOAD_ERROR = 'ca/experiments/LOAD_ERROR';
+export const SET = 'ca/experiments/SET';
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case LOAD:
+      return initialState;
+    case LOAD_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+      };
+    case LOAD_ERROR:
+      return {
+        ...state,
+        loading: false,
+        error: action.error,
+      };
+    case SET:
+      return {
+        ...state,
+        list: action.data,
+      };
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;
+
+/* Actions */
+
+export const load = () => dispatch => {
+  dispatch({ type: LOAD });
+  return api
+    .getExperiments()
+    .then(res =>
+      dispatch({
+        type: SET,
+        data: res,
+      })
+    )
+    .then(() => dispatch({ type: LOAD_SUCCESS }))
+    .catch(e => {
+      dispatch(addErrors(e));
+      dispatch({ type: LOAD_ERROR, error: e });
+    });
+};

--- a/src/state/experiments.test.js
+++ b/src/state/experiments.test.js
@@ -1,0 +1,113 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import reducer, {
+  initialState,
+  LOAD,
+  LOAD_SUCCESS,
+  LOAD_ERROR,
+  SET,
+  load,
+} from './experiments';
+import { ADD as ERROR_ADD } from './errors';
+
+const mockStore = configureMockStore([thunk]);
+
+describe('experiments/reducer', () => {
+  it('LOAD', () => {
+    expect(reducer(initialState, { type: LOAD })).toMatchSnapshot();
+  });
+
+  it('LOAD_SUCCESS', () => {
+    expect(
+      reducer(
+        { ...initialState, loading: true },
+        {
+          type: LOAD_SUCCESS,
+          index: 1,
+        }
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('LOAD_ERROR', () => {
+    expect(
+      reducer(
+        { ...initialState, loading: true },
+        { type: LOAD_ERROR, error: 'test error' }
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('SET', () => {
+    expect(
+      reducer(initialState, { type: SET, data: [{ some: 'data' }] })
+    ).toMatchSnapshot();
+  });
+});
+
+describe('experiments/actions', () => {
+  describe('load', () => {
+    it('success', () => {
+      const store = mockStore({
+        experiment: initialState,
+      });
+
+      const expList = [
+        {
+          id: 1,
+          name: 'experiment name',
+        },
+        {
+          id: 2,
+          name: 'experiment name',
+        },
+      ];
+
+      fetch.mockResponse(
+        JSON.stringify({
+          data: expList,
+        })
+      );
+
+      store.dispatch(load(1)).then(() => {
+        expect(store.getActions()).toEqual([
+          {
+            type: LOAD,
+          },
+          {
+            type: SET,
+            data: expList,
+          },
+          {
+            type: LOAD_SUCCESS,
+          },
+        ]);
+      });
+    });
+
+    it('error', () => {
+      const store = mockStore({
+        experiment: initialState,
+      });
+
+      const errText = 'some error';
+      fetch.mockReject(errText);
+
+      store.dispatch(load(1)).then(() => {
+        expect(store.getActions()).toEqual([
+          {
+            type: LOAD,
+          },
+          {
+            type: ERROR_ADD,
+            error: errText,
+          },
+          {
+            type: LOAD_ERROR,
+            error: [errText],
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 import user, { authMiddleware } from './user';
+import experiments from './experiments';
 import experiment, { middleware as expMiddleware } from './experiment';
 import assignments, {
   middleware as assignmentsMiddleware,
@@ -21,6 +22,7 @@ export default combineReducers({
   router,
   errors,
   user,
+  experiments,
   experiment,
   assignments,
   filePairs,


### PR DESCRIPTION
Implements functionality for #149.

Based on:
https://github.com/src-d/code-annotation/pull/152
https://github.com/src-d/code-annotation/pull/154

`mark as finished` link is commented, we don't have API for it now.

there are +2 queries to DB for each experiment, we can optimize it later if we need (if we will have like thousands of experiments). For now, I decided to keep it more flexible not performant.