### PR TITLE
Fe multiple experiments support

### DIFF
--- a/src/pages/Experiment.js
+++ b/src/pages/Experiment.js
@@ -11,7 +11,6 @@ import Diff from '../components/Experiment/Diff';
 import Selector from '../components/Experiment/Selector';
 import Actions from '../components/Experiment/Actions';
 import AdditionActions from '../components/Experiment/AdditionActions';
-import { experimentId } from '../state/experiment';
 import {
   markCurrent,
   ANSWER_SIMILAR,
@@ -82,6 +81,7 @@ class Experiment extends Component {
 
   renderContent() {
     const {
+      expId,
       fileLoading,
       diffString,
       leftLoc,
@@ -122,7 +122,7 @@ class Experiment extends Component {
               title="Previous"
               options={assignmentsOptions}
               value={currentAssigmentId}
-              onChange={e => selectAssigmentId(e.target.value)}
+              onChange={e => selectAssigmentId(expId, e.target.value)}
             />
           </Col>
           <Col xs={6} className="ex-page__actions">
@@ -133,7 +133,7 @@ class Experiment extends Component {
             />
           </Col>
           <Col xs={3} className="ex-page__additional-actions">
-            <AdditionActions skip={skip} finish={finish} />
+            <AdditionActions skip={skip} finish={() => finish(expId)} />
           </Col>
         </Row>
       </React.Fragment>
@@ -143,7 +143,7 @@ class Experiment extends Component {
 
 const mapStateToProps = state => {
   const { experiment, assignments } = state;
-  const { error, loading, name, description } = experiment;
+  const { error, loading, id, name, description } = experiment;
   const { list, currentAssigment } = assignments;
 
   const filePair = getCurrentFilePair(state);
@@ -157,6 +157,7 @@ const mapStateToProps = state => {
   return {
     error,
     loading,
+    expId: id,
     name,
     description,
     percent: getProgressPercent(state),
@@ -173,11 +174,9 @@ const mapDispatchToProps = dispatch => ({
   markMaybe: () => dispatch(markCurrent(ANSWER_MAYBE)),
   markDifferent: () => dispatch(markCurrent(ANSWER_DIFFERENT)),
   skip: () => dispatch(markCurrent(ANSWER_SKIP)),
-  selectAssigmentId: id =>
-    dispatch(
-      push(makeUrl('question', { experiment: experimentId, question: id }))
-    ),
-  finish: () => dispatch(push(makeUrl('finish', { experiment: experimentId }))),
+  selectAssigmentId: (expId, id) =>
+    dispatch(push(makeUrl('question', { experiment: expId, question: id }))),
+  finish: expId => dispatch(push(makeUrl('finish', { experiment: expId }))),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Experiment);

--- a/src/state/assignments.js
+++ b/src/state/assignments.js
@@ -11,8 +11,6 @@ export const ANSWER_MAYBE = 'maybe';
 export const ANSWER_DIFFERENT = 'no';
 export const ANSWER_SKIP = 'skip';
 
-export const experimentId = 1; // hard-coded id for only experiment
-
 /* reducer */
 
 export const initialState = {
@@ -189,11 +187,13 @@ export const middleware = store => next => action => {
   const result = next(action);
   const { payload } = action;
   const { experiment } = store.getState();
+  let experimentId;
   let promise;
   switch (payload.route) {
     case namedRoutes.question:
+      experimentId = +payload.params.experiment;
       promise = Promise.resolve();
-      if (experiment.id !== +payload.params.experiment) {
+      if (experiment.id !== experimentId) {
         promise = next(expLoad(experimentId));
       }
       return promise
@@ -202,8 +202,9 @@ export const middleware = store => next => action => {
           next(selectAssigment(experimentId, +payload.params.question))
         );
     case namedRoutes.finish:
+      experimentId = +payload.params.experiment;
       promise = Promise.resolve();
-      if (experiment.id !== +payload.params.experiment) {
+      if (experiment.id !== experimentId) {
         promise = next(expLoad(experimentId));
       }
       return promise.then(() => next(load(experimentId)));

--- a/src/state/experiment.js
+++ b/src/state/experiment.js
@@ -4,8 +4,6 @@ import { namedRoutes } from './routes';
 import { add as addErrors } from './errors';
 import { load as loadAssigments, undoneAssigment } from './assignments';
 
-export const experimentId = 1; // hard-coded id for only experiment
-
 /* reducer */
 
 export const initialState = {
@@ -79,8 +77,10 @@ export const middleware = () => next => action => {
 
   const result = next(action);
   const { payload } = action;
+  let experimentId;
   switch (payload.route) {
     case namedRoutes.experiment:
+      experimentId = +payload.params.experiment;
       return next(load(experimentId))
         .then(() => next(loadAssigments(experimentId)))
         .then(() => next(undoneAssigment(experimentId, replace)));

--- a/src/state/user.js
+++ b/src/state/user.js
@@ -1,6 +1,7 @@
 import { LOCATION_CHANGED, replace, push } from 'redux-little-router';
 import api from '../api';
 import { add as addError } from './errors';
+import { makeUrl } from './routes';
 import TokenService from '../services/token';
 
 const initialState = {
@@ -77,7 +78,7 @@ export const authMiddleware = store => next => action => {
       }
       // redirect user from index page to experiment if user it authorized already
       if (user.loggedIn && result && result.name === 'index') {
-        return next(push('/exp/1'));
+        return next(push(makeUrl('dashboard')));
       }
       // hide pages that are meant only for users with the requester role
       if (user.role !== 'requester' && result && result.restrictReviewer) {


### PR DESCRIPTION
Implements functionality for #149.

Based on:
https://github.com/src-d/code-annotation/pull/152
https://github.com/src-d/code-annotation/pull/154
https://github.com/src-d/code-annotation/pull/156

Now the list of experiments is default page when user login.
Annotation works fine for experiments with id > 1.

Review link still points on the first experiment though. It's possible to open review for other experiments changing url, but no link. Most probably the experiments list page should be modified and links should be there. After we can remove the one from top bar. But we don't have wireframes for that.