### PR TITLE
Import command multiple experiments support

### DIFF
--- a/cli/import/import.go
+++ b/cli/import/import.go
@@ -46,6 +46,7 @@ var opts struct {
 		Input  string `description:"SQLite database filepath"`
 		Output string `description:"SQLite or PostgreSQL Data Source Name"`
 	} `positional-args:"yes" required:"yes"`
+	ExperimentID int `long:"experiment-id" description:"Experiment ID to which files will be imported" required:"yes"`
 }
 
 func main() {
@@ -85,7 +86,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	success, failures, err := dbutil.ImportFiles(originDB, destDB, dbutil.Options{})
+	success, failures, err := dbutil.ImportFiles(originDB, destDB, dbutil.Options{}, opts.ExperimentID)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Partly implements https://github.com/src-d/code-annotation/issues/149

Looks like we don't really need to change any other commands.
There is no way to create new experiment through command line, but I think it's better to work on https://github.com/src-d/code-annotation/issues/160 than creating more commands.
These changes are necessary because import itself will be used in handler.