### PR TITLE
Make output format of logger compatible with fluentd

### DIFF
--- a/server/service/logger.go
+++ b/server/service/logger.go
@@ -1,22 +1,78 @@
 package service
 
 import (
+	"encoding/json"
+	"fmt"
+	"time"
+
 	"github.com/sirupsen/logrus"
 )
 
 // NewLogger returns a logrus Logger
 func NewLogger(env string) *logrus.Logger {
 	logger := logrus.New()
-	logger.Formatter = &logrus.TextFormatter{
-		FullTimestamp:   true,
-		TimestampFormat: "2006-01-02 15:04:05",
-	}
 
 	if env == "dev" {
+		logger.Formatter = &logrus.TextFormatter{
+			FullTimestamp:   true,
+			TimestampFormat: "2006-01-02 15:04:05",
+		}
 		logger.SetLevel(logrus.DebugLevel)
 	} else {
+		logger.Formatter = &FluentdFormatter{}
 		logger.SetLevel(logrus.WarnLevel)
 	}
 
 	return logger
+}
+
+// FluentdFormatter is similar to logrus.JSONFormatter but with log level that are recognized
+// by kubernetes fluentd.
+type FluentdFormatter struct {
+	TimestampFormat string
+}
+
+// Format the log entry. Implements logrus.Formatter.
+func (f *FluentdFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	data := make(logrus.Fields, len(entry.Data)+3)
+	for k, v := range entry.Data {
+		switch v := v.(type) {
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			// https://github.com/Sirupsen/logrus/issues/137
+			data[k] = v.Error()
+		default:
+			data[k] = v
+		}
+	}
+	prefixFieldClashes(data)
+
+	timestampFormat := f.TimestampFormat
+	if timestampFormat == "" {
+		timestampFormat = time.RFC3339
+	}
+
+	data["time"] = entry.Time.Format(timestampFormat)
+	data["message"] = entry.Message
+	data["severity"] = entry.Level.String()
+
+	serialized, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+	}
+	return append(serialized, '\n'), nil
+}
+
+func prefixFieldClashes(data logrus.Fields) {
+	if t, ok := data["time"]; ok {
+		data["fields.time"] = t
+	}
+
+	if m, ok := data["msg"]; ok {
+		data["fields.msg"] = m
+	}
+
+	if l, ok := data["level"]; ok {
+		data["fields.level"] = l
+	}
 }


### PR DESCRIPTION
Part of https://github.com/src-d/code-annotation/issues/123

Better make it configurable somehow. For example make a new environmental variable which can be `TextFormatter`, `JsonFormatter`, `FluentdFormatter`. And then additional variables to configure json formatter... But for now it looks like overkill.