### PR TITLE
Fix crash on not found

### DIFF
--- a/src/state/filePairs.js
+++ b/src/state/filePairs.js
@@ -147,11 +147,12 @@ export const middleware = store => next => action => {
 
   const result = next(action);
   const { payload } = action;
-  const expIdParam = +payload.params.experiment;
   const { experiment } = store.getState();
+  let expIdParam;
   let promise;
   switch (payload.route) {
     case namedRoutes.review:
+      expIdParam = +payload.params.experiment;
       return next(expLoad(expIdParam)).then(() =>
         next(load(expIdParam)).then(() => {
           const { filePairs } = store.getState();
@@ -169,6 +170,7 @@ export const middleware = store => next => action => {
         })
       );
     case namedRoutes.reviewPair:
+      expIdParam = +payload.params.experiment;
       promise = Promise.resolve();
       if (experiment.id !== expIdParam) {
         promise = next(expLoad(expIdParam)).then(() => next(load(expIdParam)));

--- a/src/state/routes.test.js
+++ b/src/state/routes.test.js
@@ -17,6 +17,16 @@ describe('routers', () => {
     expect(store.getActions()).toEqual([action]);
   });
 
+  it('not found', () => {
+    const store = MiddlewaredMockStore(reducer(undefined, {}));
+    const action = {
+      type: LOCATION_CHANGED,
+      payload: {},
+    };
+    store.dispatch(action);
+    expect(store.getActions()).toEqual([]);
+  });
+
   describe('experiment', () => {
     it('should load experiment and redirect to question page', () => {
       const store = MiddlewaredMockStore(


### PR DESCRIPTION
In the test, there are no actions because the store doesn't use enhancer from redux-little-router.