### PR TITLE
Change ci to carlosms fork to hotfix issue with tag names in drone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,14 @@ DOCKER_OS = linux
 DOCKER_ARCH = amd64
 
 # Including ci Makefile
-CI_REPOSITORY ?= https://github.com/src-d/ci.git
+#CI_REPOSITORY ?= https://github.com/src-d/ci.git
+CI_REPOSITORY ?= https://github.com/carlosms/ci.git
+#CI_BRANCH ?= v1
+CI_BRANCH ?= add-drone-v1
 CI_PATH ?= $(shell pwd)/.ci
 MAKEFILE := $(CI_PATH)/Makefile.main
 $(MAKEFILE):
-	@git clone --quiet --depth 1 -b v1 $(CI_REPOSITORY) $(CI_PATH);
+	@git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)
 
 # Set enviroment variables from .env file


### PR DESCRIPTION
Hotfix to solve the problem with tag version in binary names as described by https://github.com/src-d/code-annotation/issues/159#issuecomment-368648245

it could be fixed by https://github.com/src-d/ci/pull/58