### PR TITLE
Manage Experiments from the front

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -61,10 +61,16 @@ function apiCall(url, options = {}) {
       Authorization: `Bearer ${token}`,
     },
   };
+
   if (options.body) {
-    fetchOptions.body = JSON.stringify(options.body);
-    fetchOptions.headers['Content-Type'] = 'application/json';
+    if (options.formData) {
+      fetchOptions.body = options.body;
+    } else {
+      fetchOptions.body = JSON.stringify(options.body);
+      fetchOptions.headers['Content-Type'] = 'application/json';
+    }
   }
+
   return fetch(apiUrl(url), fetchOptions)
     .then(checkStatus)
     .then(resp => resp.json())
@@ -89,8 +95,33 @@ function getExperiments() {
   return apiCall(`/api/experiments`);
 }
 
+function createExperiment(name, description) {
+  return apiCall(`/api/experiments`, {
+    method: 'POST',
+    body: { name, description },
+  });
+}
+
+function updateExperiment(experimentId, name, description) {
+  return apiCall(`/api/experiments/${experimentId}`, {
+    method: 'PUT',
+    body: { name, description },
+  });
+}
+
 function getExperiment(experimentId) {
   return apiCall(`/api/experiments/${experimentId}`);
+}
+
+function uploadFilePairs(experimentId, file) {
+  const formData = new FormData();
+  formData.append('input_db', file);
+
+  return apiCall(`/api/experiments/${experimentId}/file-pairs`, {
+    method: 'POST',
+    formData: true,
+    body: formData,
+  });
 }
 
 function getAssignments(experimentId) {
@@ -145,7 +176,10 @@ export default {
   auth,
   me,
   getExperiments,
+  createExperiment,
+  updateExperiment,
   getExperiment,
+  uploadFilePairs,
   getAssignments,
   getFilePair,
   putAnswer,

--- a/src/components/Experiments/ExperimentEditModal.js
+++ b/src/components/Experiments/ExperimentEditModal.js
@@ -1,0 +1,182 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+import {
+  Button,
+  Modal,
+  FormGroup,
+  FormControl,
+  Glyphicon,
+  Row,
+  Col,
+} from 'react-bootstrap';
+
+import {
+  create as experimentCreate,
+  update as experimentUpdate,
+  uploadFilePairs,
+  UPLOAD_RES_SUCCESS,
+  UPLOAD_RES_FAILURE,
+} from '../../state/experiments';
+
+import './ExperimentEditModal.less';
+
+class ExperimentEditModal extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = this.buildState(this.props);
+
+    this.handleNameChange = this.handleNameChange.bind(this);
+    this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
+    this.handleSave = this.handleSave.bind(this);
+    this.handleUpload = this.handleUpload.bind(this);
+  }
+
+  buildState(props) {
+    const exp = props.editModalExperiment;
+
+    if (props.action === 'edit' && exp !== undefined) {
+      return { nameVal: exp.name, descriptionVal: exp.description };
+    }
+
+    return { nameVal: '', descriptionVal: '' };
+  }
+
+  handleNameChange(e) {
+    this.setState({ nameVal: e.target.value });
+  }
+
+  handleDescriptionChange(e) {
+    this.setState({ descriptionVal: e.target.value });
+  }
+
+  handleSave() {
+    const create = this.props.action === 'create';
+
+    if (create) {
+      return this.props
+        .experimentCreate(this.state.nameVal, this.state.descriptionVal)
+        .then(expId => {
+          this.props.onOpenEdit(expId);
+        })
+        .catch(() => {});
+    }
+
+    return this.props.experimentUpdate(
+      this.props.editModalExperiment.id,
+      this.state.nameVal,
+      this.state.descriptionVal
+    );
+  }
+
+  handleUpload(e) {
+    this.props.uploadFilePairs(
+      this.props.editModalExperiment.id,
+      e.target.files[0]
+    );
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.editModalExperiment !== this.props.editModalExperiment) {
+      this.setState(this.buildState(nextProps));
+    }
+  }
+
+  render() {
+    const {
+      createInProgress,
+      updateInProgress,
+      uploadInProgress,
+      uploadResult,
+    } = this.props.experiments;
+
+    const create = this.props.action === 'create';
+
+    const title = create ? 'Create Experiment' : 'Edit Experiment';
+    const btn = create ? 'Create' : 'Save';
+    const btnDisabled =
+      createInProgress || updateInProgress || this.state.nameVal.trim() === '';
+
+    const uploadDisabled = create || uploadInProgress;
+
+    let uploadIcon;
+    let uploadClass;
+    if (uploadInProgress) {
+      uploadIcon = 'floppy-open';
+      uploadClass = 'upload-floppy upload-floppy-progress';
+    } else if (uploadResult === UPLOAD_RES_SUCCESS) {
+      uploadIcon = 'floppy-saved';
+      uploadClass = 'upload-floppy upload-floppy-success';
+    } else if (uploadResult === UPLOAD_RES_FAILURE) {
+      uploadIcon = 'floppy-remove';
+      uploadClass = 'upload-floppy upload-floppy-failure';
+    } else {
+      uploadIcon = 'floppy-disk';
+      uploadClass = 'upload-floppy';
+    }
+
+    return (
+      <Modal show={this.props.show} onHide={this.props.onHide}>
+        <Modal.Header closeButton>
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <FormGroup controlId="nameInput">
+            <FormControl
+              type="text"
+              value={this.state.nameVal}
+              placeholder="Experiment name"
+              onChange={this.handleNameChange}
+            />
+          </FormGroup>
+          <FormGroup controlId="descInput">
+            <FormControl
+              type="text"
+              value={this.state.descriptionVal}
+              placeholder="Experiment description"
+              onChange={this.handleDescriptionChange}
+            />
+          </FormGroup>
+          <hr />
+          <Row>
+            <Col xs={7}>
+              <p>
+                <Glyphicon className={uploadClass} glyph={uploadIcon} />
+                <b> Experiment Dataset</b> SQLite DB file
+              </p>
+            </Col>
+            <Col xs={5} className="text-right">
+              <FormGroup controlId="uploadTest">
+                <FormControl
+                  type="file"
+                  onChange={this.handleUpload}
+                  disabled={uploadDisabled}
+                />
+              </FormGroup>
+            </Col>
+          </Row>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            bsStyle="primary"
+            disabled={btnDisabled}
+            onClick={this.handleSave}
+          >
+            {btn}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  experiments: state.experiments,
+});
+
+export default connect(mapStateToProps, {
+  experimentCreate,
+  experimentUpdate,
+  uploadFilePairs,
+})(ExperimentEditModal);

--- a/src/components/Experiments/ExperimentEditModal.less
+++ b/src/components/Experiments/ExperimentEditModal.less
@@ -1,0 +1,16 @@
+@import '../../../node_modules/bootstrap/less/variables.less';
+
+.upload-floppy {
+	font-size: 2em;
+	vertical-align: middle;
+
+	&-progress {
+
+	}
+	&-success {
+		color: @brand-success;
+	}
+	&-failure {
+		color: @brand-danger;
+	}
+}

--- a/src/components/ExperimentsList.js
+++ b/src/components/ExperimentsList.js
@@ -1,58 +1,82 @@
-import React from 'react';
-import { Table, Button } from 'react-bootstrap';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Table, Button, Glyphicon } from 'react-bootstrap';
 import { makeUrl } from '../state/routes';
 import './ExperimentsList.less';
 
-function buttonText(progress) {
-  switch (progress) {
-    case 0:
-      return 'Begin';
-    case 100:
-      return 'Finished';
-    default:
-      return 'Continue';
+class ExperimentsList extends Component {
+  handleOpenEdit(expId) {
+    return () => this.props.onOpenEdit(expId);
+  }
+
+  buttonText(progress) {
+    switch (progress) {
+      case 0:
+        return 'Begin';
+      case 100:
+        return 'Finished';
+      default:
+        return 'Continue';
+    }
+  }
+
+  render() {
+    return (
+      <Table responsive className="experiments-list">
+        <tbody>
+          {this.props.experiments.map(exp => {
+            // const started = exp.progress === 0;
+            const finished = exp.progress === 100;
+            return (
+              <tr
+                key={exp.id}
+                className={`experiments-list__row${
+                  finished ? ' finished' : ''
+                }`}
+              >
+                <td className="experiments-list__name">{exp.name}</td>
+                {this.props.user.role === 'requester' && (
+                  <td className="experiments-list__edit">
+                    <Button
+                      bsStyle="link"
+                      onClick={this.handleOpenEdit(exp.id)}
+                    >
+                      <Glyphicon glyph="edit" />
+                    </Button>
+                  </td>
+                )}
+                <td className="experiments-list__progress">
+                  {Math.round(exp.progress)}%
+                </td>
+                <td className="experiments-list__additional-actions">
+                  {/*
+                    {!finished && !started ? (
+                        <a href="/">mark as finished</a>
+                      ) : null}
+                  */}
+                </td>
+                <td className="experiments-list__actions">
+                  <Button
+                    bsStyle="primary"
+                    bsSize="xsmall"
+                    disabled={finished}
+                    href={makeUrl('experiment', { experiment: exp.id })}
+                  >
+                    {this.buttonText(exp.progress)}
+                  </Button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+    );
   }
 }
 
-function ExperimentsList({ experiments }) {
-  return (
-    <Table responsive className="experiments-list">
-      <tbody>
-        {experiments.map(exp => {
-          // const started = exp.progress === 0;
-          const finished = exp.progress === 100;
-          return (
-            <tr
-              key={exp.id}
-              className={`experiments-list__row${finished ? ' finished' : ''}`}
-            >
-              <td className="experiments-list__name">{exp.name}</td>
-              <td className="experiments-list__progress">
-                {Math.round(exp.progress)}%
-              </td>
-              <td className="experiments-list__additional-actions">
-                {/*
-                  {!finished && !started ? (
-                      <a href="/">mark as finished</a>
-                    ) : null}
-                */}
-              </td>
-              <td className="experiments-list__actions">
-                <Button
-                  bsStyle="primary"
-                  bsSize="xsmall"
-                  disabled={finished}
-                  href={makeUrl('experiment', { experiment: exp.id })}
-                >
-                  {buttonText(exp.progress)}
-                </Button>
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </Table>
-  );
-}
+const mapStateToProps = state => ({
+  user: state.user,
+  experiments: state.experiments.list,
+});
 
-export default ExperimentsList;
+export default connect(mapStateToProps)(ExperimentsList);

--- a/src/components/ExperimentsList.less
+++ b/src/components/ExperimentsList.less
@@ -3,6 +3,10 @@
 .experiments-list {
     &__actions {
         text-align: center;
+
+        .btn {
+            width: 140px;
+        }
     }
 
     td {
@@ -30,9 +34,5 @@
 
     &__row.finished {
         color: #ccc;
-    }
-
-    .btn {
-        width: 140px;
     }
 }

--- a/src/pages/Experiments.js
+++ b/src/pages/Experiments.js
@@ -1,14 +1,54 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Grid, Row, Col } from 'react-bootstrap';
+import { Grid, Row, Col, Button, Glyphicon } from 'react-bootstrap';
 import Page from './Page';
 import Loader from '../components/Loader';
 import ExperimentsList from '../components/ExperimentsList';
-import { load as experimentsLoad } from '../state/experiments';
+import ExperimentsEditModal from '../components/Experiments/ExperimentEditModal';
+import {
+  load as experimentsLoad,
+  uploadResultReset,
+} from '../state/experiments';
+import './Experiments.less';
 
 class Experiments extends Component {
+  constructor(props) {
+    super(props);
+
+    this.handleOpenNew = this.handleOpenNew.bind(this);
+    this.handleOpenEdit = this.handleOpenEdit.bind(this);
+    this.handleCloseModal = this.handleCloseModal.bind(this);
+
+    this.state = {
+      editModalShow: false,
+      editModalAction: 'create',
+      editExperimentId: undefined,
+    };
+  }
+
   componentDidMount() {
     this.props.load();
+  }
+
+  handleOpenNew() {
+    this.setState({
+      editModalShow: true,
+      editModalAction: 'create',
+    });
+  }
+
+  handleOpenEdit(experimentId) {
+    this.props.uploadResultReset();
+
+    this.setState({
+      editModalShow: true,
+      editModalAction: 'edit',
+      editExperimentId: experimentId,
+    });
+  }
+
+  handleCloseModal() {
+    this.setState({ editModalShow: false });
   }
 
   render() {
@@ -17,7 +57,7 @@ class Experiments extends Component {
 
   renderContent() {
     const { user, experiments } = this.props;
-    const { error, loading, list } = experiments;
+    const { error, loading, createInProgress } = experiments;
 
     if (error) {
       return (
@@ -39,6 +79,32 @@ class Experiments extends Component {
       );
     }
 
+    let addRow = '';
+    if (user.role === 'requester') {
+      addRow = (
+        <Row>
+          <Col xs={8} xsOffset={2} className="text-right">
+            <Button
+              bsStyle="link"
+              onClick={this.handleOpenNew}
+              disabled={createInProgress}
+              className="ex-page__plus-btn"
+            >
+              <Glyphicon glyph="plus-sign" />
+            </Button>
+          </Col>
+        </Row>
+      );
+    }
+
+    let editModalExperiment;
+
+    if (this.state.editModalAction === 'edit') {
+      editModalExperiment = experiments.list.find(
+        e => e.id === this.state.editExperimentId
+      );
+    }
+
     return (
       <React.Fragment>
         <Row>
@@ -49,17 +115,25 @@ class Experiments extends Component {
           </Col>
         </Row>
         <Row>
-          <Col xs={12}>
+          <Col xs={12} style={{ paddingBottom: '40px' }}>
             <p className="text-center">
               Here&#39;s your experiments dashboard, go ahead and make our day.
             </p>
           </Col>
         </Row>
+        {addRow}
         <Row>
-          <Col xs={8} xsOffset={2} style={{ paddingTop: '40px' }}>
-            <ExperimentsList experiments={list} />
+          <Col xs={8} xsOffset={2}>
+            <ExperimentsList onOpenEdit={this.handleOpenEdit} />
           </Col>
         </Row>
+        <ExperimentsEditModal
+          action={this.state.editModalAction}
+          editModalExperiment={editModalExperiment}
+          show={this.state.editModalShow}
+          onHide={this.handleCloseModal}
+          onOpenEdit={this.handleOpenEdit}
+        />
       </React.Fragment>
     );
   }
@@ -70,7 +144,10 @@ const mapStateToProps = state => ({
   experiments: state.experiments,
 });
 
-export default connect(mapStateToProps, { load: experimentsLoad })(
+export default connect(mapStateToProps, {
+  load: experimentsLoad,
+  uploadResultReset,
+})(
   Page(Experiments, {
     className: 'experiments-page',
     titleFn: () => 'Experiments',

--- a/src/pages/Experiments.less
+++ b/src/pages/Experiments.less
@@ -1,0 +1,5 @@
+.ex-page {
+    &__plus-btn {
+		font-size: 1.4em;
+	}
+}

--- a/src/state/__snapshots__/experiments.test.js.snap
+++ b/src/state/__snapshots__/experiments.test.js.snap
@@ -1,31 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`experiments/reducer LOAD 1`] = `
+exports[`experiments/reducer CREATE 1`] = `
 Object {
+  "createInProgress": true,
   "error": null,
   "list": Array [],
   "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
+}
+`;
+
+exports[`experiments/reducer CREATE_ERROR 1`] = `
+Object {
+  "createInProgress": false,
+  "error": "test error",
+  "list": Array [],
+  "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
+}
+`;
+
+exports[`experiments/reducer CREATE_SUCCESS 1`] = `
+Object {
+  "createInProgress": false,
+  "error": null,
+  "list": Array [],
+  "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
+}
+`;
+
+exports[`experiments/reducer LOAD 1`] = `
+Object {
+  "createInProgress": false,
+  "error": null,
+  "list": Array [],
+  "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
 }
 `;
 
 exports[`experiments/reducer LOAD_ERROR 1`] = `
 Object {
+  "createInProgress": false,
   "error": "test error",
   "list": Array [],
   "loading": false,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
 }
 `;
 
 exports[`experiments/reducer LOAD_SUCCESS 1`] = `
 Object {
+  "createInProgress": false,
   "error": null,
   "list": Array [],
   "loading": false,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
 }
 `;
 
 exports[`experiments/reducer SET 1`] = `
 Object {
+  "createInProgress": false,
   "error": null,
   "list": Array [
     Object {
@@ -33,5 +82,92 @@ Object {
     },
   ],
   "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
+}
+`;
+
+exports[`experiments/reducer UPDATE 1`] = `
+Object {
+  "createInProgress": false,
+  "error": null,
+  "list": Array [],
+  "loading": true,
+  "updateInProgress": true,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
+}
+`;
+
+exports[`experiments/reducer UPDATE_ERROR 1`] = `
+Object {
+  "createInProgress": false,
+  "error": "test error",
+  "list": Array [],
+  "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
+}
+`;
+
+exports[`experiments/reducer UPDATE_SUCCESS 1`] = `
+Object {
+  "createInProgress": false,
+  "error": null,
+  "list": Array [],
+  "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
+}
+`;
+
+exports[`experiments/reducer UPLOAD 1`] = `
+Object {
+  "createInProgress": false,
+  "error": null,
+  "list": Array [],
+  "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": true,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
+}
+`;
+
+exports[`experiments/reducer UPLOAD_ERROR 1`] = `
+Object {
+  "createInProgress": false,
+  "error": "test error",
+  "list": Array [],
+  "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_FAILURE",
+}
+`;
+
+exports[`experiments/reducer UPLOAD_RESULT_RESET 1`] = `
+Object {
+  "createInProgress": false,
+  "error": null,
+  "list": Array [],
+  "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_NONE",
+}
+`;
+
+exports[`experiments/reducer UPLOAD_SUCCESS 1`] = `
+Object {
+  "createInProgress": false,
+  "error": null,
+  "list": Array [],
+  "loading": true,
+  "updateInProgress": false,
+  "uploadInProgress": false,
+  "uploadResult": "ca/experiments/UPLOAD_RES_SUCCESS",
 }
 `;

--- a/src/state/experiments.js
+++ b/src/state/experiments.js
@@ -3,9 +3,17 @@ import { add as addErrors } from './errors';
 
 /* reducer */
 
+export const UPLOAD_RES_NONE = 'ca/experiments/UPLOAD_RES_NONE';
+export const UPLOAD_RES_SUCCESS = 'ca/experiments/UPLOAD_RES_SUCCESS';
+export const UPLOAD_RES_FAILURE = 'ca/experiments/UPLOAD_RES_FAILURE';
+
 export const initialState = {
   loading: true,
   error: null,
+  createInProgress: false,
+  updateInProgress: false,
+  uploadInProgress: false,
+  uploadResult: UPLOAD_RES_NONE,
 
   list: [],
 };
@@ -14,11 +22,26 @@ export const LOAD = 'ca/experiments/LOAD';
 export const LOAD_SUCCESS = 'ca/experiments/LOAD_SUCCESS';
 export const LOAD_ERROR = 'ca/experiments/LOAD_ERROR';
 export const SET = 'ca/experiments/SET';
+export const CREATE = 'ca/experiments/CREATE';
+export const CREATE_SUCCESS = 'ca/experiments/CREATE_SUCCESS';
+export const CREATE_ERROR = 'ca/experiments/CREATE_ERROR';
+export const UPDATE = 'ca/experiments/UPDATE';
+export const UPDATE_SUCCESS = 'ca/experiments/UPDATE_SUCCESS';
+export const UPDATE_ERROR = 'ca/experiments/UPDATE_ERROR';
+export const UPLOAD = 'ca/experiments/UPLOAD';
+export const UPLOAD_SUCCESS = 'ca/experiments/UPLOAD_SUCCESS';
+export const UPLOAD_ERROR = 'ca/experiments/UPLOAD_ERROR';
+export const UPLOAD_RESULT_RESET = 'ca/experiments/UPLOAD_RESULT_RESET';
 
 const reducer = (state = initialState, action) => {
   switch (action.type) {
     case LOAD:
-      return initialState;
+      return {
+        ...state,
+        loading: true,
+        error: null,
+        list: [],
+      };
     case LOAD_SUCCESS:
       return {
         ...state,
@@ -34,6 +57,65 @@ const reducer = (state = initialState, action) => {
       return {
         ...state,
         list: action.data,
+      };
+    case CREATE:
+      return {
+        ...state,
+        error: null,
+        createInProgress: true,
+      };
+    case CREATE_SUCCESS:
+      return {
+        ...state,
+        createInProgress: false,
+      };
+    case CREATE_ERROR:
+      return {
+        ...state,
+        createInProgress: false,
+        error: action.error,
+      };
+    case UPDATE:
+      return {
+        ...state,
+        error: null,
+        updateInProgress: true,
+      };
+    case UPDATE_SUCCESS:
+      return {
+        ...state,
+        updateInProgress: false,
+      };
+    case UPDATE_ERROR:
+      return {
+        ...state,
+        updateInProgress: false,
+        error: action.error,
+      };
+    case UPLOAD:
+      return {
+        ...state,
+        error: null,
+        uploadInProgress: true,
+        uploadResult: UPLOAD_RES_NONE,
+      };
+    case UPLOAD_SUCCESS:
+      return {
+        ...state,
+        uploadInProgress: false,
+        uploadResult: UPLOAD_RES_SUCCESS,
+      };
+    case UPLOAD_ERROR:
+      return {
+        ...state,
+        uploadInProgress: false,
+        uploadResult: UPLOAD_RES_FAILURE,
+        error: action.error,
+      };
+    case UPLOAD_RESULT_RESET:
+      return {
+        ...state,
+        uploadResult: UPLOAD_RES_NONE,
       };
 
     default:
@@ -59,5 +141,52 @@ export const load = () => dispatch => {
     .catch(e => {
       dispatch(addErrors(e));
       dispatch({ type: LOAD_ERROR, error: e });
+    });
+};
+
+export const create = (name, description) => dispatch => {
+  dispatch({ type: CREATE });
+  return api
+    .createExperiment(name, description)
+    .then(res => {
+      dispatch({ type: CREATE_SUCCESS });
+      dispatch(load());
+      return res.id;
+    })
+    .catch(e => {
+      dispatch(addErrors(e));
+      dispatch({ type: CREATE_ERROR, error: e });
+      throw e;
+    });
+};
+
+export const update = (id, name, description) => dispatch => {
+  dispatch({ type: UPDATE });
+  return api
+    .updateExperiment(id, name, description)
+    .then(() => {
+      dispatch({ type: UPDATE_SUCCESS });
+      dispatch(load());
+    })
+    .catch(e => {
+      dispatch(addErrors(e));
+      dispatch({ type: UPDATE_ERROR, error: e });
+    });
+};
+
+export const uploadResultReset = () => dispatch => {
+  dispatch({ type: UPLOAD_RESULT_RESET });
+};
+
+export const uploadFilePairs = (experimentId, file) => dispatch => {
+  dispatch({ type: UPLOAD });
+  return api
+    .uploadFilePairs(experimentId, file)
+    .then(() => {
+      dispatch({ type: UPLOAD_SUCCESS });
+    })
+    .catch(e => {
+      dispatch(addErrors(e));
+      dispatch({ type: UPLOAD_ERROR, error: e });
     });
 };

--- a/src/state/experiments.test.js
+++ b/src/state/experiments.test.js
@@ -6,7 +6,23 @@ import reducer, {
   LOAD_SUCCESS,
   LOAD_ERROR,
   SET,
+  CREATE,
+  CREATE_SUCCESS,
+  CREATE_ERROR,
+  UPDATE,
+  UPDATE_SUCCESS,
+  UPDATE_ERROR,
+  UPLOAD,
+  UPLOAD_SUCCESS,
+  UPLOAD_ERROR,
+  UPLOAD_RESULT_RESET,
+  UPLOAD_RES_NONE,
+  UPLOAD_RES_SUCCESS,
   load,
+  create,
+  update,
+  uploadFilePairs,
+  uploadResultReset,
 } from './experiments';
 import { ADD as ERROR_ADD } from './errors';
 
@@ -43,13 +59,107 @@ describe('experiments/reducer', () => {
       reducer(initialState, { type: SET, data: [{ some: 'data' }] })
     ).toMatchSnapshot();
   });
+
+  it('CREATE', () => {
+    expect(reducer(initialState, { type: CREATE })).toMatchSnapshot();
+  });
+
+  it('CREATE_SUCCESS', () => {
+    expect(
+      reducer(
+        { ...initialState, createInProgress: true },
+        { type: CREATE_SUCCESS }
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('CREATE_ERROR', () => {
+    expect(
+      reducer(
+        { ...initialState, createInProgress: true },
+        { type: CREATE_ERROR, error: 'test error' }
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('UPDATE', () => {
+    expect(reducer(initialState, { type: UPDATE })).toMatchSnapshot();
+  });
+
+  it('UPDATE_SUCCESS', () => {
+    expect(
+      reducer(
+        { ...initialState, updateInProgress: true },
+        { type: UPDATE_SUCCESS }
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('UPDATE_ERROR', () => {
+    expect(
+      reducer(
+        { ...initialState, updateInProgress: true },
+        { type: UPDATE_ERROR, error: 'test error' }
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('UPLOAD', () => {
+    expect(reducer(initialState, { type: UPLOAD })).toMatchSnapshot();
+  });
+
+  it('UPLOAD_SUCCESS', () => {
+    expect(
+      reducer(
+        {
+          ...initialState,
+          uploadInProgress: true,
+          uploadResult: UPLOAD_RES_NONE,
+        },
+        { type: UPLOAD_SUCCESS }
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('UPLOAD_ERROR', () => {
+    expect(
+      reducer(
+        {
+          ...initialState,
+          uploadInProgress: true,
+          uploadResult: UPLOAD_RES_NONE,
+        },
+        { type: UPLOAD_ERROR, error: 'test error' }
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('UPLOAD_RESULT_RESET', () => {
+    expect(
+      reducer(
+        {
+          ...initialState,
+          uploadInProgress: false,
+          uploadResult: UPLOAD_RES_SUCCESS,
+        },
+        { type: UPLOAD_RESULT_RESET }
+      )
+    ).toMatchSnapshot();
+  });
 });
+
+const mockRes = {
+  id: 3,
+  name: 'new_name',
+  description: 'new_desc',
+  progress: 0,
+};
 
 describe('experiments/actions', () => {
   describe('load', () => {
     it('success', () => {
       const store = mockStore({
-        experiment: initialState,
+        experiments: initialState,
       });
 
       const expList = [
@@ -69,7 +179,7 @@ describe('experiments/actions', () => {
         })
       );
 
-      store.dispatch(load(1)).then(() => {
+      store.dispatch(load()).then(() => {
         expect(store.getActions()).toEqual([
           {
             type: LOAD,
@@ -93,7 +203,7 @@ describe('experiments/actions', () => {
       const errText = 'some error';
       fetch.mockReject(errText);
 
-      store.dispatch(load(1)).then(() => {
+      store.dispatch(load()).then(() => {
         expect(store.getActions()).toEqual([
           {
             type: LOAD,
@@ -108,6 +218,148 @@ describe('experiments/actions', () => {
           },
         ]);
       });
+    });
+  });
+
+  describe('create', () => {
+    it('success', () => {
+      const store = mockStore({ experiments: initialState });
+
+      fetch.mockResponseOnce(JSON.stringify({ data: mockRes }));
+
+      store.dispatch(create('new_name', 'new_desc')).then(() => {
+        expect(store.getActions()).toEqual([
+          {
+            type: CREATE,
+          },
+          {
+            type: CREATE_SUCCESS,
+          },
+          {
+            type: LOAD,
+          },
+        ]);
+      });
+    });
+
+    it('error', () => {
+      const store = mockStore({ experiments: initialState });
+
+      const errText = 'some error';
+      fetch.mockReject(errText);
+
+      expect.hasAssertions();
+
+      store.dispatch(create('new_name', 'new_desc')).catch(() => {
+        expect(store.getActions()).toEqual([
+          {
+            type: CREATE,
+          },
+          {
+            type: ERROR_ADD,
+            error: errText,
+          },
+          {
+            type: CREATE_ERROR,
+            error: [errText],
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('success', () => {
+      const store = mockStore({ experiments: initialState });
+
+      fetch.mockResponseOnce(JSON.stringify({ data: mockRes }));
+
+      store.dispatch(update(3, 'new_name', 'new_desc')).then(() => {
+        expect(store.getActions()).toEqual([
+          {
+            type: UPDATE,
+          },
+          {
+            type: UPDATE_SUCCESS,
+          },
+          {
+            type: LOAD,
+          },
+        ]);
+      });
+    });
+
+    it('error', () => {
+      const store = mockStore({ experiments: initialState });
+
+      const errText = 'some error';
+      fetch.mockReject(errText);
+
+      store.dispatch(update(3, 'new_name', 'new_desc')).then(() => {
+        expect(store.getActions()).toEqual([
+          {
+            type: UPDATE,
+          },
+          {
+            type: ERROR_ADD,
+            error: errText,
+          },
+          {
+            type: UPDATE_ERROR,
+            error: [errText],
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('upload', () => {
+    it('success', () => {
+      const store = mockStore({ experiments: initialState });
+
+      fetch.mockResponseOnce(JSON.stringify({ data: mockRes }));
+
+      store.dispatch(uploadFilePairs(3, 'file')).then(() => {
+        expect(store.getActions()).toEqual([
+          {
+            type: UPLOAD,
+          },
+          {
+            type: UPLOAD_SUCCESS,
+          },
+        ]);
+      });
+    });
+
+    it('error', () => {
+      const store = mockStore({ experiments: initialState });
+
+      const errText = 'some error';
+      fetch.mockReject(errText);
+
+      store.dispatch(uploadFilePairs(3, 'file')).then(() => {
+        expect(store.getActions()).toEqual([
+          {
+            type: UPLOAD,
+          },
+          {
+            type: ERROR_ADD,
+            error: errText,
+          },
+          {
+            type: UPLOAD_ERROR,
+            error: [errText],
+          },
+        ]);
+      });
+    });
+
+    it('reset', () => {
+      const store = mockStore({ experiments: initialState });
+
+      store.dispatch(uploadResultReset());
+
+      expect(store.getActions()).toEqual([{ type: UPLOAD_RESULT_RESET }]);
     });
   });
 });


### PR DESCRIPTION
Part of #160, this PR will add a new route to create & edit experiments, and a way to upload a new SQLite DB with file pairs.