### PR TITLE
Add production value for GA_TRACKING_ID

### DIFF
--- a/helm-charts/code-annotation/values.yaml
+++ b/helm-charts/code-annotation/values.yaml
@@ -12,7 +12,7 @@ image:
   pullPolicy: IfNotPresent
 deployment:
     internalDatabasePath: "/var/code-annotation"
-    gaTrackingID: ""
+    gaTrackingID: "UA-109494282-2"
 authorization:
     restrictAccessGroup: "org:src-d"
     restrictRequesterGroup: ""


### PR DESCRIPTION
Fix #169

Add production value for GA_TRACKING_ID as provided by https://github.com/src-d/code-annotation/issues/169#issuecomment-369632517

There won't be available data at GA panel until the next release.