### PR TITLE
Build binary for darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ BINDATA = go-bindata
 
 # ci variables
 TRAVIS_BUILD_DIR ?= $(shell pwd)
-PKG_OS = linux
 DOCKER_OS = linux
 DOCKER_ARCH = amd64
 


### PR DESCRIPTION
Fix: https://github.com/src-d/code-annotation/issues/184

I couldn't test drone, but according to the rules there ( https://github.com/src-d/code-annotation/blob/master/.drone.yml#L84 ) macOs binary will be upload.