### PR TITLE
Configure the Production environment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ workspace:
   base: /go
   path: src/github.com/src-d/code-annotation
 
-branches: [master, staging, release/*]
+branches: [master, staging]
 
 # ANCHORS
 
@@ -27,6 +27,14 @@ docker_image: &docker_image
   dockerfile: Dockerfile
   debug: true
 
+helm_deploy: &helm_deploy
+  image: quay.io/ipedrazas/drone-helm
+  skip_tls_verify: true
+  chart: ./helm-charts/code-annotation
+  release: code-annotation
+  tiller_ns: kube-system
+  wait: true
+
 # PIPELINE STEPS
 
 pipeline:
@@ -36,7 +44,7 @@ pipeline:
     debug: true
 
 
-  # deployment to staging environment
+  # deployment to staging environment when staging is pushed
 
   build_stg:
     <<: *build
@@ -53,20 +61,17 @@ pipeline:
       event: [push]
 
   helm_deploy_stg:
-    image: quay.io/ipedrazas/drone-helm
-    skip_tls_verify: true
-    chart: ./helm-charts/code-annotation
-    release: code-annotation
+    <<: *helm_deploy
     prefix: STG
     secrets: [ STG_API_SERVER, STG_KUBERNETES_TOKEN ]
-    values: ingress.globalStaticIpName=code-annotation-staging,ingress.hostname=code-annotation-staging.srcd.run,image.tag=commit-${DRONE_COMMIT_SHA:0:7},secretName=code-annotation-drone-workaround
-    tiller_ns: kube-system
-    wait: true
+    values: ingress.globalStaticIpName=code-annotation-staging,ingress.hostname=code-annotation-staging.srcd.run,image.tag=commit-${DRONE_COMMIT_SHA:0:7},deployment.gaTrackingID=UA-109494282-2,secretName=code-annotation-drone-workaround
     when:
       branch: [staging]
       event: [push]
 
-  # push build artifacts to GitHub release
+  # deployment to Production environment when a new tag is created; it will also:
+  # - push to GitHub release, the compiled binaries,
+  # - push to DockerHub, the docker image
 
   build_release:
     <<: *build
@@ -85,5 +90,13 @@ pipeline:
     image: plugins/github-release
     secrets: [ github_token ]
     files: build/*.tar.gz
+    when:
+      event: [tag]
+
+  helm_deploy_release_prod:
+    <<: *helm_deploy
+    prefix: PROD
+    secrets: [ PROD_API_SERVER, PROD_KUBERNETES_TOKEN ]
+    values: ingress.globalStaticIpName=code-annotation-production,ingress.hostname=code-annotation.sourced.tech,image.tag=${DRONE_TAG},deployment.gaTrackingID=UA-109494282-2,secretName=code-annotation-drone-workaround
     when:
       event: [tag]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ CAT_OAUTH_RESTRICT_ACCESS=org:my-organization
 CAT_OAUTH_RESTRICT_REQUESTER_ACCESS=team:123456
 ```
 
+## Deployment
+
+This site is deployed in `production` and in `staging` following our [web application deployment workflow](https://github.com/src-d/guide/blob/master/engineering/continuous-delivery.md)
+
 ## Contributing
 
 [Contributions](https://github.com/src-d/code-annotation/issues) are more than welcome, if you are interested please take a look to our [Contributing Guidelines](CONTRIBUTING.md). You have more information on how to run it locally for [development purposes here](CONTRIBUTING.md#Development).

--- a/helm-charts/code-annotation/templates/deployment.yaml
+++ b/helm-charts/code-annotation/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
                   name: {{ $secretName  }}
                   key: jwt_signing_key
             - name: CAT_GA_TRACKING_ID
-              value: "{{ .Values.deployment.gaTrackingID }}"
+              value: "{{ required "gaTrackingID is required" .Values.deployment.gaTrackingID }}"
           ports:
             - containerPort: {{ .Values.service.codeAnnotation.internalPort }}
           volumeMounts:

--- a/helm-charts/code-annotation/values.yaml
+++ b/helm-charts/code-annotation/values.yaml
@@ -12,7 +12,7 @@ image:
   pullPolicy: IfNotPresent
 deployment:
     internalDatabasePath: "/var/code-annotation"
-    gaTrackingID: "UA-109494282-2"
+    # gaTrackingID must be received as a parameter
 authorization:
     restrictAccessGroup: "org:src-d"
     restrictRequesterGroup: ""
@@ -28,7 +28,7 @@ ingress:
     kubernetes.io/ingress.class: gce
   tls: true
   # below values are required
-  # hostname: "code-annotation-staging.srcd.run"
+  # hostname: "code-annotation.sourced.tech"
   # globalStaticIpName: "code-annotation-ip"
 
 # Provide with 'helm install', and do NOT change it when doing 'helm upgrade'


### PR DESCRIPTION
required by https://github.com/src-d/code-annotation/issues/215

This PR prepares the Prod env.

Changes done:
- this application now is deployed into Staging and Production following [our continuous-delivery guide](https://github.com/src-d/guide/blob/master/engineering/continuous-delivery.md),
  - every new tag will trigger a deploy into Production,
- `gaTrackingID` must be passed by drone.io when deploying
  - Staging will have its own `GA_TRACKING_ID` for testing purposes
- Staging will no longer be accessible for no @src-d/applications members

Other changes that should be done by @src-d/infrastructure just after merging this PR:
- https://github.com/src-d/issues-infrastructure/issues/152
