### PR TITLE
Avoid external dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,8 @@ DOCKER_OS = linux
 DOCKER_ARCH = amd64
 
 # Including ci Makefile
-#CI_REPOSITORY ?= https://github.com/src-d/ci.git
-CI_REPOSITORY ?= https://github.com/carlosms/ci.git
-#CI_BRANCH ?= v1
-CI_BRANCH ?= add-drone-v1
+CI_REPOSITORY ?= https://github.com/src-d/ci.git
+CI_BRANCH ?= v1
 CI_PATH ?= $(shell pwd)/.ci
 MAKEFILE := $(CI_PATH)/Makefile.main
 $(MAKEFILE):


### PR DESCRIPTION
Depends on ~~https://github.com/src-d/code-annotation/pull/230~~ https://github.com/src-d/ci/pull/58 https://github.com/src-d/ci/pull/60 https://github.com/src-d/ci/pull/61

Use [src-d/ci:v1](https://github.com/src-d/ci/tree/v1) to avoid external dependencies 