### PR TITLE
Remove diff column

### DIFF
--- a/server/dbutil/dbutil.go
+++ b/server/dbutil/dbutil.go
@@ -56,7 +56,7 @@ const (
 		id <INCREMENT_TYPE>,
 		blob_id_a TEXT, repository_id_a TEXT, commit_hash_a TEXT, path_a TEXT, content_a TEXT, hash_a TEXT,
 		blob_id_b TEXT, repository_id_b TEXT, commit_hash_b TEXT, path_b TEXT, content_b TEXT, hash_b TEXT,
-		score DOUBLE PRECISION, diff TEXT, experiment_id INTEGER,
+		score DOUBLE PRECISION, experiment_id INTEGER,
 		uast_a <BLOB_TYPE>, uast_b <BLOB_TYPE>,
 		PRIMARY KEY (id),
 		FOREIGN KEY(experiment_id) REFERENCES experiments(id))`
@@ -95,8 +95,8 @@ const selectFiles = `SELECT
 const insertFilePairs = `INSERT INTO file_pairs (
 		blob_id_a, repository_id_a, commit_hash_a, path_a, content_a, hash_a, uast_a,
 		blob_id_b, repository_id_b, commit_hash_b, path_b, content_b, hash_b, uast_b,
-		score, diff, experiment_id ) VALUES
-		($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`
+		score, experiment_id ) VALUES
+		($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`
 
 var (
 	sqliteReg = regexp.MustCompile(`^sqlite://(.+)$`)
@@ -202,7 +202,7 @@ func (opts *Options) getLogger() logrus.FieldLogger {
 }
 
 // ImportFiles imports pairs of files from the origin to the destination DB.
-// It copies the contents and processes the needed data (md5 hash, diff)
+// It copies the contents and processes the needed data (md5 hash)
 func ImportFiles(originDB DB, destDB DB, opts Options, experimentID int) (success, failures int64, e error) {
 
 	logger := opts.getLogger()
@@ -255,7 +255,6 @@ func ImportFiles(originDB DB, destDB DB, opts Options, experimentID int) (succes
 			blobIDA, repositoryIDA, commitHashA, pathA, contentA, md5hash(contentA), uastA,
 			blobIDB, repositoryIDB, commitHashB, pathB, contentB, md5hash(contentB), uastB,
 			score,
-			"",
 			experimentID)
 
 		if err != nil {


### PR DESCRIPTION
Diff was no longer needed since https://github.com/src-d/code-annotation/pull/194

The Staging internal database will be migrated with (via https://github.com/src-d/code-annotation/pull/221)
```shel
go run cli/migrations/*.go diff-rm-col internal.db
```