### PR TITLE
Request features from Review section with one call

### DIFF
--- a/server/handler/features.go
+++ b/server/handler/features.go
@@ -3,24 +3,51 @@ package handler
 import (
 	"net/http"
 
-	"github.com/go-chi/chi"
+	"github.com/src-d/code-annotation/server/model"
 	"github.com/src-d/code-annotation/server/repository"
 	"github.com/src-d/code-annotation/server/serializer"
 )
 
 // GetFeatures returns a function that returns a *serializer.Response
 // with the list of features for blobId
-func GetFeatures(repo *repository.Features) RequestProcessFunc {
+func GetFeatures(filePairRepo *repository.FilePairs, featuresRepo *repository.Features) RequestProcessFunc {
 	return func(r *http.Request) (*serializer.Response, error) {
-		blobID := chi.URLParam(r, "blobId")
-
-		// in the future it should take file by blobID from DB
-		// and make API request to ML system
-		features, err := repo.GetAll(blobID)
+		filePairID, err := urlParamInt(r, "pairId")
 		if err != nil {
 			return nil, err
 		}
 
-		return serializer.NewFeaturesResponse(features), nil
+		filePair, err := filePairRepo.GetByID(filePairID)
+		if err != nil {
+			return nil, err
+		}
+
+		featuresA, featuresB, score, err := getFeatures(featuresRepo, filePair)
+		if err != nil {
+			return nil, err
+		}
+
+		return serializer.NewFeaturesResponse(featuresA, featuresB, score), nil
 	}
+}
+
+// TODO (dpordomingo): in the future it should take the UAST of both blobs DB
+// and make a request to ML feature extractor API
+func getFeatures(repo *repository.Features, pair *model.FilePair) ([]*model.Feature, []*model.Feature, *model.Feature, error) {
+	blobIDA := pair.Left.BlobID
+	blobIDB := pair.Right.BlobID
+
+	featuresA, err := repo.GetAll(blobIDA)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	featuresB, err := repo.GetAll(blobIDB)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	score := model.Feature{Name: "score", Weight: pair.Score}
+
+	return featuresA, featuresB, &score, err
 }

--- a/server/router.go
+++ b/server/router.go
@@ -89,10 +89,10 @@ func Router(
 			r.Get("/file-pairs/{pairId}", handler.APIHandlerFunc(handler.GetFilePairDetails(filePairRepo, diffService)))
 		})
 
-		r.Route("/features", func(r chi.Router) {
+		r.Route("/file-pair", func(r chi.Router) {
 			r.Use(requesterACL.Middleware)
 
-			r.Get("/{blobId}", handler.APIHandlerFunc(handler.GetFeatures(featureRepo)))
+			r.Get("/{pairId}/features", handler.APIHandlerFunc(handler.GetFeatures(filePairRepo, featureRepo)))
 		})
 
 		r.Route("/exports", func(r chi.Router) {

--- a/server/serializer/serializers.go
+++ b/server/serializer/serializers.go
@@ -192,13 +192,29 @@ type featureResponse struct {
 	Weight float64 `json:"weight"`
 }
 
-// NewFeaturesResponse returns a Response for the passed Features
-func NewFeaturesResponse(fs []*model.Feature) *Response {
-	features := make([]featureResponse, len(fs))
-	for i, f := range fs {
-		features[i] = featureResponse(*f)
+type featuresResponse struct {
+	Object1 []featureResponse `json:"featuresA"`
+	Object2 []featureResponse `json:"featuresB"`
+	Pair    featureResponse   `json:"score"`
+}
+
+// NewFeaturesResponse returns a Response for the passed Features and score
+func NewFeaturesResponse(fsA []*model.Feature, fsB []*model.Feature, s *model.Feature) *Response {
+	featuresA := make([]featureResponse, len(fsA))
+	for i, f := range fsA {
+		featuresA[i] = featureResponse(*f)
 	}
-	return newResponse(features)
+
+	featuresB := make([]featureResponse, len(fsB))
+	for i, f := range fsB {
+		featuresB[i] = featureResponse(*f)
+	}
+
+	return newResponse(featuresResponse{
+		Object1: featuresA,
+		Object2: featuresB,
+		Pair:    featureResponse(*s),
+	})
 }
 
 type countResponse struct {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -158,8 +158,8 @@ function getFilePairAnnotations(experimentId, id) {
   );
 }
 
-function getFeatures(blobId) {
-  return apiCall(`/api/features/${blobId}`);
+function getFeatures(filePairId) {
+  return apiCall(`/api/file-pair/${filePairId}/features`);
 }
 
 function exportList() {

--- a/src/pages/Review.js
+++ b/src/pages/Review.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-bootstrap';
+import { push } from 'redux-little-router';
 import SplitPane from 'react-split-pane';
 import Page from './Page';
 import Loader from '../components/Loader';
@@ -8,11 +9,8 @@ import Breadcrumbs from '../components/Breadcrumbs';
 import Selector from '../components/Experiment/Selector';
 import Diff from '../components/Experiment/Diff';
 import Results from '../components/Review/Results';
-import {
-  getCurrentFilePair,
-  selectPair,
-  loadFilePair,
-} from '../state/filePairs';
+import { makeUrl } from '../state/routes';
+import { getCurrentFilePair, loadFilePair } from '../state/filePairs';
 import {
   getFeatures,
   mostSimilar,
@@ -160,7 +158,10 @@ const mapStateToProps = state => {
 
 const experimentId = 1;
 const mapDispatchToProps = dispatch => ({
-  onSelect: pairId => dispatch(selectPair(experimentId, pairId)),
+  onSelect: pairId =>
+    dispatch(
+      push(makeUrl('reviewPair', { experiment: experimentId, pair: pairId }))
+    ),
   toggleInvisible: (expId, id) => {
     dispatch(toggleInvisible());
     return dispatch(loadFilePair(expId, id));

--- a/src/pages/Review.js
+++ b/src/pages/Review.js
@@ -13,7 +13,12 @@ import {
   selectPair,
   loadFilePair,
 } from '../state/filePairs';
-import { getFeatures, mostSimilar, leastSimilar } from '../state/features';
+import {
+  getFeatures,
+  mostSimilar,
+  leastSimilar,
+  getScore,
+} from '../state/features';
 import { toggleInvisible } from '../state/user';
 import './Review.less';
 
@@ -64,6 +69,7 @@ class Review extends Component {
       mostSimilarFeatures,
       leastSimilarFeatures,
       features,
+      score,
     } = this.props;
 
     if (fileLoading || !filePair) {
@@ -102,7 +108,7 @@ class Review extends Component {
               />
               <Results
                 className="results"
-                score={filePair.score}
+                score={score}
                 annotations={annotations}
                 features={features}
                 mostSimilarFeatures={mostSimilarFeatures}
@@ -127,6 +133,7 @@ const mapStateToProps = state => {
     name: `(${i + 1})`,
   }));
 
+  const score = getScore(state);
   const features = getFeatures(state);
   // keep only 100 results
   // it will be improved (most probably with pagination) later
@@ -146,6 +153,7 @@ const mapStateToProps = state => {
     mostSimilarFeatures,
     leastSimilarFeatures,
     features,
+    score,
     showInvisible,
   };
 };

--- a/src/state/features.test.js
+++ b/src/state/features.test.js
@@ -27,47 +27,44 @@ describe('features/reducer', () => {
 describe('features/actions', () => {
   describe('load', () => {
     it('success', () => {
-      const blobIdA = 1;
-      const blobIdB = 2;
+      const filePairId = 1;
       const store = mockStore({
         features: {
           ...initialState,
         },
       });
 
-      fetch.mockResponses(
-        // blobA response
-        [
-          JSON.stringify({
-            data: [
+      fetch.mockResponses([
+        JSON.stringify({
+          data: {
+            featuresA: [
               { name: 'feature1', weight: 0.9 },
               { name: 'feature2', weight: 0.8 },
             ],
-          }),
-        ],
-        // blobB response
-        [
-          JSON.stringify({
-            data: [
+            featuresB: [
               { name: 'feature1', weight: 0.8 },
               { name: 'feature3', weight: 0.1 },
             ],
-          }),
-        ]
-      );
+            score: { name: 'score', weight: 0.5 },
+          },
+        }),
+      ]);
 
-      return store.dispatch(load(blobIdA, blobIdB)).then(() => {
+      return store.dispatch(load(filePairId)).then(() => {
         expect(store.getActions()).toEqual([
           {
             type: LOAD,
           },
           {
             type: LOAD_SUCCESS,
-            features: [
-              { name: 'feature1', weightA: 0.9, weightB: 0.8 },
-              { name: 'feature2', weightA: 0.8, weightB: 0 },
-              { name: 'feature3', weightA: 0, weightB: 0.1 },
-            ],
+            features: {
+              features: [
+                { name: 'feature1', weightA: 0.9, weightB: 0.8 },
+                { name: 'feature2', weightA: 0.8, weightB: 0 },
+                { name: 'feature3', weightA: 0, weightB: 0.1 },
+              ],
+              score: 0.5,
+            },
           },
         ]);
       });
@@ -103,13 +100,16 @@ describe('features/actions', () => {
 describe('features/selectors', () => {
   const stateForSort = {
     features: {
-      features: [
-        { name: 'a', weightA: 5, weightB: 10 },
-        { name: 'b', weightA: 10, weightB: 10 },
-        { name: 'c', weightA: 10, weightB: 1 },
-        { name: 'b', weightA: 2, weightB: 2 },
-        { name: 'd', weightA: 10, weightB: 10 },
-      ],
+      features: {
+        features: [
+          { name: 'a', weightA: 5, weightB: 10 },
+          { name: 'b', weightA: 10, weightB: 10 },
+          { name: 'c', weightA: 10, weightB: 1 },
+          { name: 'b', weightA: 2, weightB: 2 },
+          { name: 'd', weightA: 10, weightB: 10 },
+        ],
+        score: 0.5,
+      },
     },
   };
 

--- a/src/state/filePairs.js
+++ b/src/state/filePairs.js
@@ -192,7 +192,7 @@ export const middleware = store => next => action => {
         .then(() => next(loadAnnotations(expIdParam, +payload.params.pair)))
         .then(() => {
           const pair = getCurrentFilePair(store.getState());
-          return pair && next(featuresLoad(pair.leftBlobId, pair.rightBlobId));
+          return pair && next(featuresLoad(pair.id));
         });
     default:
       return result;

--- a/src/state/routes.test.js
+++ b/src/state/routes.test.js
@@ -288,17 +288,14 @@ describe('routers', () => {
           }),
           { status: 200 },
         ],
-        // features left
+        // features
         [
           JSON.stringify({
-            data: [],
-          }),
-          { status: 200 },
-        ],
-        // features right
-        [
-          JSON.stringify({
-            data: [],
+            data: {
+              featuresA: [],
+              featuresB: [],
+              score: {},
+            },
           }),
           { status: 200 },
         ]


### PR DESCRIPTION
required by #198 and https://github.com/src-d/backlog/issues/1202
fixes #229

As defined by https://github.com/src-d/code-annotation/issues/198#issuecomment-375703060, the [ML Feature Extractor API](https://github.com/src-d/backlog/issues/1202) will take a couple of UAST, and it will return a bunch of features per each UAST, and a `score` as a _pair-feature_

This PR prepares the frontend to do one call per FilePair being reviewed to obtain the features of each file, and the score itself.
This PR prepares the backend to answer following the expected schema.

No UI changes were done.

It was also added a 
3445eb0 commit to fix #229 because otherwise the FilePairs beyond the first one cannot be reviewed.

## Pending work

To be done once the [ML Feature Extractor API](https://github.com/src-d/backlog/issues/1202) is ready, but that does not block this PR:
- the new API musth be called from the features handler (pointed by the [TODO](https://github.com/src-d/code-annotation/pull/233/files#diff-ae70b50bc82721e179675b32e8aa5845R34)),
- the [`model.Features`](https://github.com/src-d/code-annotation/blob/master/server/model/models.go#L64) must be removed,
- the [`features` db table](https://github.com/src-d/code-annotation/blob/master/server/dbutil/dbutil.go#L65) must be removed &rarr; running `features-drop-table` migration from https://github.com/src-d/code-annotation/pull/221