### PR TITLE
Avoid console messages in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,6 @@ module.exports = {
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
     'react/prop-types': 0,
     'class-methods-use-this': 0, // strange rule. It doesn't allow to create method render() without this
-    'no-console': ['error', { allow: ['info', 'warn', 'error'] }], // later we will might need wrapper
     'no-case-declarations': 0, // otherwise code is very ugly
   },
 };

--- a/src/services/log.js
+++ b/src/services/log.js
@@ -1,0 +1,6 @@
+const noop = () => undefined;
+
+export default {
+  // eslint-disable-next-line no-console
+  error: process.env.NODE_ENV !== 'test' ? console.error.bind(console) : noop,
+};

--- a/src/state/errors.js
+++ b/src/state/errors.js
@@ -1,3 +1,5 @@
+import log from '../services/log';
+
 export const initialState = [];
 
 export const ADD = 'ca/errors/ADD';
@@ -18,7 +20,7 @@ const reducer = (state = initialState, action) => {
 };
 
 export const add = error => dispatch => {
-  console.error(error);
+  log.error(error);
   if (Array.isArray(error)) {
     error.forEach(e =>
       dispatch({


### PR DESCRIPTION
As required by https://github.com/bblfsh/dashboard/issues/86 
>_We need to avoid console messages in tests_

and done by https://github.com/bblfsh/dashboard/pull/112, this PR avoid console messages in CAT tests.