### PR TITLE
Moved to cert-manager

### DIFF
--- a/helm-charts/code-annotation/Chart.yaml
+++ b/helm-charts/code-annotation/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: code-annotation
-version: 0.0.1
+version: 0.1.0

--- a/helm-charts/code-annotation/templates/ingress.yaml
+++ b/helm-charts/code-annotation/templates/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    stable.k8s.psg.io/kcm.class: {{ .Values.ingress.kcmClass }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/helm-charts/code-annotation/values.yaml
+++ b/helm-charts/code-annotation/values.yaml
@@ -23,9 +23,9 @@ service:
     internalPort: 8080
     name: code-annotation
 ingress:
-  kcmClass: default
   annotations:
     kubernetes.io/ingress.class: gce
+    kubernetes.io/tls-acme: "true"
   tls: true
   # below values are required
   # hostname: "code-annotation.srcd.run"


### PR DESCRIPTION
kube-cert-manager is no longer supported so we are moving everything to
cert-manager

Signed-off-by: David Riosalido <driosalido@sourced.tech>